### PR TITLE
✨ [Feature] 하단 네비게이션 바 구현 (#12)

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,0 +1,24 @@
+import type { BottomTabBarProps } from '@react-navigation/bottom-tabs';
+import { Tabs } from 'expo-router';
+import { View, StyleSheet } from 'react-native';
+import TabBar from '../../src/components/common/TabBar';
+import colors from '../../src/constants/colors';
+
+const renderTabBar = ({ state, descriptors, navigation, insets }: BottomTabBarProps) => (
+  <TabBar state={state} descriptors={descriptors} navigation={navigation} insets={insets} />
+);
+
+const TabsLayout = () => (
+  <View style={styles.root}>
+    <Tabs tabBar={renderTabBar} screenOptions={{ headerShown: false }} />
+  </View>
+);
+
+export default TabsLayout;
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: colors.text.white,
+  },
+});

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -1,0 +1,25 @@
+import { View, Text, StyleSheet } from 'react-native';
+import colors from '../../src/constants/colors';
+import fonts from '../../src/constants/fonts';
+
+const Screen = () => (
+  <View style={styles.container}>
+    <Text style={styles.text}>calendar</Text>
+  </View>
+);
+
+export default Screen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.text.white,
+  },
+  text: {
+    fontSize: 18,
+    fontFamily: fonts.semiBold,
+    color: colors.text.primary,
+  },
+});

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -2,13 +2,13 @@ import { View, Text, StyleSheet } from 'react-native';
 import colors from '../../src/constants/colors';
 import fonts from '../../src/constants/fonts';
 
-const Screen = () => (
+const CalendarScreen = () => (
   <View style={styles.container}>
     <Text style={styles.text}>calendar</Text>
   </View>
 );
 
-export default Screen;
+export default CalendarScreen;
 
 const styles = StyleSheet.create({
   container: {

--- a/app/(tabs)/document.tsx
+++ b/app/(tabs)/document.tsx
@@ -2,13 +2,13 @@ import { View, Text, StyleSheet } from 'react-native';
 import colors from '../../src/constants/colors';
 import fonts from '../../src/constants/fonts';
 
-const Screen = () => (
+const DocumentScreen = () => (
   <View style={styles.container}>
     <Text style={styles.text}>document</Text>
   </View>
 );
 
-export default Screen;
+export default DocumentScreen;
 
 const styles = StyleSheet.create({
   container: {

--- a/app/(tabs)/document.tsx
+++ b/app/(tabs)/document.tsx
@@ -1,0 +1,25 @@
+import { View, Text, StyleSheet } from 'react-native';
+import colors from '../../src/constants/colors';
+import fonts from '../../src/constants/fonts';
+
+const Screen = () => (
+  <View style={styles.container}>
+    <Text style={styles.text}>document</Text>
+  </View>
+);
+
+export default Screen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.text.white,
+  },
+  text: {
+    fontSize: 18,
+    fontFamily: fonts.semiBold,
+    color: colors.text.primary,
+  },
+});

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,0 +1,25 @@
+import { View, Text, StyleSheet } from 'react-native';
+import colors from '../../src/constants/colors';
+import fonts from '../../src/constants/fonts';
+
+const HomeScreen = () => (
+  <View style={styles.container}>
+    <Text style={styles.text}>Home</Text>
+  </View>
+);
+
+export default HomeScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.text.white,
+  },
+  text: {
+    fontSize: 18,
+    fontFamily: fonts.semiBold,
+    color: colors.text.primary,
+  },
+});

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -2,13 +2,13 @@ import { View, Text, StyleSheet } from 'react-native';
 import colors from '../../src/constants/colors';
 import fonts from '../../src/constants/fonts';
 
-const Screen = () => (
+const ProfileScreen = () => (
   <View style={styles.container}>
     <Text style={styles.text}>profile</Text>
   </View>
 );
 
-export default Screen;
+export default ProfileScreen;
 
 const styles = StyleSheet.create({
   container: {

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,0 +1,25 @@
+import { View, Text, StyleSheet } from 'react-native';
+import colors from '../../src/constants/colors';
+import fonts from '../../src/constants/fonts';
+
+const Screen = () => (
+  <View style={styles.container}>
+    <Text style={styles.text}>profile</Text>
+  </View>
+);
+
+export default Screen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.text.white,
+  },
+  text: {
+    fontSize: 18,
+    fontFamily: fonts.semiBold,
+    color: colors.text.primary,
+  },
+});

--- a/app/(tabs)/scan.tsx
+++ b/app/(tabs)/scan.tsx
@@ -2,13 +2,13 @@ import { View, Text, StyleSheet } from 'react-native';
 import colors from '../../src/constants/colors';
 import fonts from '../../src/constants/fonts';
 
-const Screen = () => (
+const ScanScreen = () => (
   <View style={styles.container}>
     <Text style={styles.text}>scan</Text>
   </View>
 );
 
-export default Screen;
+export default ScanScreen;
 
 const styles = StyleSheet.create({
   container: {

--- a/app/(tabs)/scan.tsx
+++ b/app/(tabs)/scan.tsx
@@ -1,0 +1,25 @@
+import { View, Text, StyleSheet } from 'react-native';
+import colors from '../../src/constants/colors';
+import fonts from '../../src/constants/fonts';
+
+const Screen = () => (
+  <View style={styles.container}>
+    <Text style={styles.text}>scan</Text>
+  </View>
+);
+
+export default Screen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.text.white,
+  },
+  text: {
+    fontSize: 18,
+    fontFamily: fonts.semiBold,
+    color: colors.text.primary,
+  },
+});

--- a/src/components/common/TabBar.tsx
+++ b/src/components/common/TabBar.tsx
@@ -1,0 +1,148 @@
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import type { BottomTabBarProps } from '@react-navigation/bottom-tabs';
+import { Ionicons } from '@expo/vector-icons';
+import Svg, { Defs, RadialGradient, Stop, Circle } from 'react-native-svg';
+import colors from '../../constants/colors';
+import fonts from '../../constants/fonts';
+
+type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
+
+interface TabItem {
+  routeName: string;
+  label: string;
+  icon: IoniconName;
+  activeIcon: IoniconName;
+}
+
+const TABS: TabItem[] = [
+  { routeName: 'index', label: '홈', icon: 'home-outline', activeIcon: 'home' },
+  {
+    routeName: 'document',
+    label: '문서',
+    icon: 'document-text-outline',
+    activeIcon: 'document-text',
+  },
+  { routeName: 'scan', label: '스캔', icon: 'scan-outline', activeIcon: 'scan-outline' },
+  { routeName: 'calendar', label: '캘린더', icon: 'calendar-outline', activeIcon: 'calendar' },
+  { routeName: 'profile', label: '프로필', icon: 'person-outline', activeIcon: 'person' },
+];
+
+const TabBar = ({ state, navigation, insets }: BottomTabBarProps) => {
+  return (
+    <View style={[styles.outer, { paddingBottom: insets.bottom }]}>
+      <View style={styles.container}>
+        {TABS.map((tab) => {
+          const routeIndex = state.routes.findIndex((r) => r.name === tab.routeName);
+          const isActive = state.index === routeIndex;
+          const isScan = tab.routeName === 'scan';
+
+          const onPress = () => {
+            const event = navigation.emit({
+              type: 'tabPress',
+              target: state.routes[routeIndex].key,
+              canPreventDefault: true,
+            });
+            if (!event.defaultPrevented) {
+              navigation.navigate(tab.routeName);
+            }
+          };
+
+          if (isScan) {
+            return (
+              <TouchableOpacity
+                key={tab.routeName}
+                style={styles.scanWrapper}
+                onPress={onPress}
+                activeOpacity={0.85}
+              >
+                <View style={styles.scanButton}>
+                  <Svg width={60} height={60} style={StyleSheet.absoluteFill}>
+                    <Defs>
+                      <RadialGradient id="rg" cx="50%" cy="50%" r="50%">
+                        <Stop offset="0.28" stopColor="#47A3FF" stopOpacity="1" />
+                        <Stop offset="1" stopColor="#C1ECFC" stopOpacity="1" />
+                      </RadialGradient>
+                    </Defs>
+                    <Circle cx={30} cy={30} r={30} fill="url(#rg)" />
+                  </Svg>
+                  <Ionicons name={tab.icon} size={26} color={colors.text.white} />
+                </View>
+                <Text style={[styles.label, isActive && styles.activeLabel]}>{tab.label}</Text>
+              </TouchableOpacity>
+            );
+          }
+
+          return (
+            <TouchableOpacity
+              key={tab.routeName}
+              style={styles.tab}
+              onPress={onPress}
+              activeOpacity={0.7}
+            >
+              <Ionicons
+                name={isActive ? tab.activeIcon : tab.icon}
+                size={26}
+                color={isActive ? colors.primary[500] : colors.gray[300]}
+              />
+              <Text style={[styles.label, isActive && styles.activeLabel]}>{tab.label}</Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+    </View>
+  );
+};
+
+export default TabBar;
+
+const styles = StyleSheet.create({
+  outer: {
+    backgroundColor: colors.text.white,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    elevation: 12,
+    shadowColor: colors.text.primary,
+    shadowOffset: { width: 0, height: -2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 12,
+  },
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingTop: 15,
+    paddingBottom: 12,
+    overflow: 'visible',
+  },
+  tab: {
+    flex: 1,
+    alignItems: 'center',
+    gap: 3,
+  },
+  scanWrapper: {
+    flex: 1,
+    alignItems: 'center',
+    gap: 3,
+    marginTop: -26,
+  },
+  scanButton: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+    elevation: 4,
+    shadowColor: colors.primary[400],
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+  },
+  label: {
+    fontSize: 12,
+    fontFamily: fonts.semiBold,
+    color: colors.gray[300],
+  },
+  activeLabel: {
+    color: colors.primary[600],
+  },
+});

--- a/src/components/common/TabBar.tsx
+++ b/src/components/common/TabBar.tsx
@@ -31,14 +31,15 @@ const TabBar = ({ state, navigation, insets }: BottomTabBarProps) => (
   <View style={[styles.outer, { paddingBottom: insets.bottom }]}>
     <View style={styles.container}>
       {TABS.map((tab) => {
-        const routeIndex = state.routes.findIndex((r) => r.name === tab.routeName);
-        const isActive = state.index === routeIndex;
+        const route = state.routes.find((r) => r.name === tab.routeName);
+        const isActive = !!route && state.index === state.routes.indexOf(route);
         const isScan = tab.routeName === 'scan';
 
         const onPress = () => {
+          if (!route) return;
           const event = navigation.emit({
             type: 'tabPress',
-            target: state.routes[routeIndex].key,
+            target: route.key,
             canPreventDefault: true,
           });
           if (!event.defaultPrevented) {

--- a/src/components/common/TabBar.tsx
+++ b/src/components/common/TabBar.tsx
@@ -28,67 +28,67 @@ const TABS: TabItem[] = [
 ];
 
 const TabBar = ({ state, navigation, insets }: BottomTabBarProps) => (
-    <View style={[styles.outer, { paddingBottom: insets.bottom }]}>
-      <View style={styles.container}>
-        {TABS.map((tab) => {
-          const routeIndex = state.routes.findIndex((r) => r.name === tab.routeName);
-          const isActive = state.index === routeIndex;
-          const isScan = tab.routeName === 'scan';
+  <View style={[styles.outer, { paddingBottom: insets.bottom }]}>
+    <View style={styles.container}>
+      {TABS.map((tab) => {
+        const routeIndex = state.routes.findIndex((r) => r.name === tab.routeName);
+        const isActive = state.index === routeIndex;
+        const isScan = tab.routeName === 'scan';
 
-          const onPress = () => {
-            const event = navigation.emit({
-              type: 'tabPress',
-              target: state.routes[routeIndex].key,
-              canPreventDefault: true,
-            });
-            if (!event.defaultPrevented) {
-              navigation.navigate(tab.routeName);
-            }
-          };
-
-          if (isScan) {
-            return (
-              <TouchableOpacity
-                key={tab.routeName}
-                style={styles.scanWrapper}
-                onPress={onPress}
-                activeOpacity={0.85}
-              >
-                <View style={styles.scanButton}>
-                  <Svg width={60} height={60} style={StyleSheet.absoluteFill}>
-                    <Defs>
-                      <RadialGradient id="rg" cx="50%" cy="50%" r="50%">
-                        <Stop offset="0.28" stopColor="#47A3FF" stopOpacity="1" />
-                        <Stop offset="1" stopColor="#C1ECFC" stopOpacity="1" />
-                      </RadialGradient>
-                    </Defs>
-                    <Circle cx={30} cy={30} r={30} fill="url(#rg)" />
-                  </Svg>
-                  <Ionicons name={tab.icon} size={26} color={colors.text.white} />
-                </View>
-                <Text style={[styles.label, isActive && styles.activeLabel]}>{tab.label}</Text>
-              </TouchableOpacity>
-            );
+        const onPress = () => {
+          const event = navigation.emit({
+            type: 'tabPress',
+            target: state.routes[routeIndex].key,
+            canPreventDefault: true,
+          });
+          if (!event.defaultPrevented) {
+            navigation.navigate(tab.routeName);
           }
+        };
 
+        if (isScan) {
           return (
             <TouchableOpacity
               key={tab.routeName}
-              style={styles.tab}
+              style={styles.scanWrapper}
               onPress={onPress}
-              activeOpacity={0.7}
+              activeOpacity={0.85}
             >
-              <Ionicons
-                name={isActive ? tab.activeIcon : tab.icon}
-                size={26}
-                color={isActive ? colors.primary[500] : colors.gray[300]}
-              />
+              <View style={styles.scanButton}>
+                <Svg width={60} height={60} style={StyleSheet.absoluteFill}>
+                  <Defs>
+                    <RadialGradient id="rg" cx="50%" cy="50%" r="50%">
+                      <Stop offset="0.28" stopColor="#47A3FF" stopOpacity="1" />
+                      <Stop offset="1" stopColor="#C1ECFC" stopOpacity="1" />
+                    </RadialGradient>
+                  </Defs>
+                  <Circle cx={30} cy={30} r={30} fill="url(#rg)" />
+                </Svg>
+                <Ionicons name={tab.icon} size={26} color={colors.text.white} />
+              </View>
               <Text style={[styles.label, isActive && styles.activeLabel]}>{tab.label}</Text>
             </TouchableOpacity>
           );
-        })}
-      </View>
+        }
+
+        return (
+          <TouchableOpacity
+            key={tab.routeName}
+            style={styles.tab}
+            onPress={onPress}
+            activeOpacity={0.7}
+          >
+            <Ionicons
+              name={isActive ? tab.activeIcon : tab.icon}
+              size={26}
+              color={isActive ? colors.primary[500] : colors.gray[300]}
+            />
+            <Text style={[styles.label, isActive && styles.activeLabel]}>{tab.label}</Text>
+          </TouchableOpacity>
+        );
+      })}
     </View>
+  </View>
 );
 
 export default TabBar;

--- a/src/components/common/TabBar.tsx
+++ b/src/components/common/TabBar.tsx
@@ -27,8 +27,7 @@ const TABS: TabItem[] = [
   { routeName: 'profile', label: '프로필', icon: 'person-outline', activeIcon: 'person' },
 ];
 
-const TabBar = ({ state, navigation, insets }: BottomTabBarProps) => {
-  return (
+const TabBar = ({ state, navigation, insets }: BottomTabBarProps) => (
     <View style={[styles.outer, { paddingBottom: insets.bottom }]}>
       <View style={styles.container}>
         {TABS.map((tab) => {
@@ -90,8 +89,7 @@ const TabBar = ({ state, navigation, insets }: BottomTabBarProps) => {
         })}
       </View>
     </View>
-  );
-};
+);
 
 export default TabBar;
 


### PR DESCRIPTION
## 📌 작업 내용

- 바텀탭 네비게이터 레이아웃 및 5개 탭 화면(홈/문서/스캔/캘린더/프로필) 추가
- 커스텀 TabBar 컴포넌트 구현 (스캔 탭 중앙 floating 버튼 + 라디얼 그라디언트)
- elevation/shadow 및 borderTopRadius를 outer 뷰로 이동해 safe area 포함 자연스러운 그림자 처리
- 탭 화면 컴포넌트명 통일 (Screen → HomeScreen, DocumentScreen 등)

## 📷 스크린 샷

<img width="500" height="2400" alt="Screenshot_1776091829" src="https://github.com/user-attachments/assets/c121e741-c872-4c6b-93ff-6ed972e4e18c" />


## ⚠️ 참고 사항

- `TabBar`는 직접 사용하지 않고 `(tabs)/_layout.tsx`에서 `Tabs`의 `tabBar` prop으로 주입하는 방식으로 사용

   ```tsx
  const renderTabBar = (props: BottomTabBarProps) => <TabBar {...props} />;

  <Tabs tabBar={renderTabBar} screenOptions={{ headerShown: false }} />

## 🔗 관련 이슈

Closes #12 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bottom tab navigation with quick access to five app sections: Home, Calendar, Documents, Profile, and Scan.
  * Implemented custom tab bar with active state indicators and distinct visual styling for navigation elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->