### PR TITLE
✨ [Feature] 회원가입, 자녀 등록 API 연동

### DIFF
--- a/app/(auth)/register/basic.tsx
+++ b/app/(auth)/register/basic.tsx
@@ -21,6 +21,7 @@ import { loginIdSchema, emailSchema, validatePassword } from '../../../src/valid
 import colors from '../../../src/constants/colors';
 import fonts from '../../../src/constants/fonts';
 import layout from '../../../src/constants/layout';
+import { useRegisterStore } from '../../../src/store/registerStore';
 
 type ValidationState = 'success' | 'error' | undefined;
 
@@ -85,6 +86,7 @@ const formSchema = z
 type FormValues = z.infer<typeof formSchema>;
 
 const RegisterBasicScreen = () => {
+  const setBasicInfo = useRegisterStore((s) => s.setBasicInfo);
   const {
     control,
     getValues,
@@ -482,7 +484,17 @@ const RegisterBasicScreen = () => {
 
         <PrimaryButton
           label="다음으로 →"
-          onPress={() => router.push('/(auth)/register/child')}
+          onPress={() => {
+            const values = getValues();
+            setBasicInfo({
+              loginId: values.id,
+              password: values.password,
+              name: values.name,
+              email: values.email,
+              phoneNumber: values.phone.replace(/-/g, ''),
+            });
+            router.push('/(auth)/register/child');
+          }}
           disabled={
             !isValid ||
             idChecking ||

--- a/app/(auth)/register/child.tsx
+++ b/app/(auth)/register/child.tsx
@@ -50,7 +50,7 @@ const createChild = (id: string): ChildInfo => ({
   selectedSchool: null,
   schoolQuery: '',
   grade: null,
-  calendarColor: null,
+  calendarColor: CALENDAR_COLORS[0],
 });
 
 const shortenAddress = (address: string): string => {

--- a/app/(auth)/register/child.tsx
+++ b/app/(auth)/register/child.tsx
@@ -9,6 +9,8 @@ import { SchoolResult } from '../../../src/types/school';
 import { ChildInfo } from '../../../src/types/child';
 import cardStyles from '../../../src/styles/register/childCard';
 import styles from '../../../src/styles/register/child';
+import { useRegisterStore } from '../../../src/store/registerStore';
+import { ChildPayload } from '../../../src/api/child';
 
 // ─── 상수 ────────────────────────────────────────────────────────────────────
 
@@ -35,6 +37,12 @@ const MOCK_SCHOOLS: SchoolResult[] = [
 ];
 
 // ─── 헬퍼 ────────────────────────────────────────────────────────────────────
+
+const isChildComplete = (child: ChildInfo): boolean =>
+  child.name.trim().length > 0 &&
+  (child.selectedSchool !== null || child.schoolQuery.trim().length > 0) &&
+  child.grade !== null &&
+  child.calendarColor !== null;
 
 const createChild = (id: string): ChildInfo => ({
   id,
@@ -273,6 +281,7 @@ const ChildCard = ({ child, order, isDeletable, onUpdate, onDelete }: ChildCardP
 
 const RegisterChildScreen = () => {
   const [children, setChildren] = useState<ChildInfo[]>([createChild('1')]);
+  const setStoreChildren = useRegisterStore((s) => s.setChildren);
 
   const updateChild = (id: string, updates: Partial<ChildInfo>) => {
     setChildren((prev) => prev.map((c) => (c.id === id ? { ...c, ...updates } : c)));
@@ -347,7 +356,18 @@ const RegisterChildScreen = () => {
       <View style={styles.footer}>
         <PrimaryButton
           label="다음으로 →"
-          onPress={() => router.push('/(auth)/register/notification')}
+          disabled={children.length === 0 || !children.every(isChildComplete)}
+          onPress={() => {
+            const payloads: ChildPayload[] = children.map((child) => ({
+              name: child.name,
+              schoolName: child.selectedSchool?.name ?? child.schoolQuery,
+              schoolCode: '',
+              grade: child.grade ?? 1,
+              colorCode: child.calendarColor ?? '#2BAEE0',
+            }));
+            setStoreChildren(payloads);
+            router.push('/(auth)/register/notification');
+          }}
         />
       </View>
     </View>

--- a/app/(auth)/register/child.tsx
+++ b/app/(auth)/register/child.tsx
@@ -361,7 +361,7 @@ const RegisterChildScreen = () => {
             const payloads: ChildPayload[] = children.map((child) => ({
               name: child.name,
               schoolName: child.selectedSchool?.name ?? child.schoolQuery,
-              schoolCode: '',
+              schoolCode: child.selectedSchool?.schoolCode ?? '',
               grade: child.grade ?? 1,
               colorCode: child.calendarColor ?? '#2BAEE0',
             }));

--- a/app/(auth)/register/complete.tsx
+++ b/app/(auth)/register/complete.tsx
@@ -9,7 +9,7 @@ import colors from '../../../src/constants/colors';
 import fonts from '../../../src/constants/fonts';
 import layout from '../../../src/constants/layout';
 import { signup, login } from '../../../src/api/auth';
-import { registerChildren } from '../../../src/api/child';
+import { registerChild } from '../../../src/api/child';
 import { useRegisterStore } from '../../../src/store/registerStore';
 
 // ─── 메인 화면 ────────────────────────────────────────────────────────────────
@@ -31,8 +31,10 @@ const RegisterCompleteScreen = () => {
       children,
       signupDone,
       loginDone,
+      registeredChildrenCount,
       setSignupDone,
       setLoginDone,
+      incrementRegisteredChildrenCount,
       reset,
     } = useRegisterStore.getState();
 
@@ -68,12 +70,22 @@ const RegisterCompleteScreen = () => {
         setLoginDone(true);
         accessToken = result.accessToken;
       } else {
-        accessToken = (await SecureStore.getItemAsync('accessToken')) ?? '';
+        const stored = await SecureStore.getItemAsync('accessToken');
+        if (stored) {
+          accessToken = stored;
+        } else {
+          const result = await login(loginId, password, false);
+          await SecureStore.setItemAsync('accessToken', result.accessToken);
+          await SecureStore.setItemAsync('refreshToken', result.refreshToken);
+          accessToken = result.accessToken;
+        }
       }
 
-      if (children.length > 0) {
-        await registerChildren(children, accessToken);
-      }
+      await children.slice(registeredChildrenCount).reduce(async (prev, child) => {
+        await prev;
+        await registerChild(child, accessToken);
+        incrementRegisteredChildrenCount();
+      }, Promise.resolve());
 
       setStatus('done');
       reset();

--- a/app/(auth)/register/complete.tsx
+++ b/app/(auth)/register/complete.tsx
@@ -1,23 +1,118 @@
-import { useEffect, useRef } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { View, Text, StyleSheet, ActivityIndicator, TouchableOpacity } from 'react-native';
 import { router } from 'expo-router';
+import * as SecureStore from 'expo-secure-store';
 import Svg, { Circle, Defs, RadialGradient, Stop } from 'react-native-svg';
 import ConfettiCannon from 'react-native-confetti-cannon';
 import { PrimaryButton } from '../../../src/components/common/Button';
 import colors from '../../../src/constants/colors';
 import fonts from '../../../src/constants/fonts';
 import layout from '../../../src/constants/layout';
+import { signup, login } from '../../../src/api/auth';
+import { registerChildren } from '../../../src/api/child';
+import { useRegisterStore } from '../../../src/store/registerStore';
 
 // ─── 메인 화면 ────────────────────────────────────────────────────────────────
 
+type Status = 'loading' | 'done' | 'error';
+
 const RegisterCompleteScreen = () => {
   const confettiRef = useRef<React.ComponentRef<typeof ConfettiCannon>>(null);
+  const [status, setStatus] = useState<Status>('loading');
+  const [errorMessage, setErrorMessage] = useState<string>('');
 
-  useEffect(() => {
-    if (confettiRef.current) {
-      confettiRef.current.start();
+  const run = useCallback(async () => {
+    const {
+      loginId,
+      password,
+      name,
+      email,
+      phoneNumber,
+      children,
+      signupDone,
+      loginDone,
+      setSignupDone,
+      setLoginDone,
+      reset,
+    } = useRegisterStore.getState();
+
+    setStatus('loading');
+    setErrorMessage('');
+
+    if (!loginId) {
+      setStatus('error');
+      setErrorMessage('회원가입 정보가 없어요. 처음부터 다시 시도해주세요.');
+      return;
+    }
+
+    try {
+      if (!signupDone) {
+        await signup({
+          name,
+          email,
+          loginId,
+          password,
+          passwordConfirm: password,
+          phoneNumber,
+          consentAgreed: true,
+        });
+        setSignupDone(true);
+      }
+
+      let accessToken: string;
+
+      if (!loginDone) {
+        const result = await login(loginId, password, false);
+        await SecureStore.setItemAsync('accessToken', result.accessToken);
+        await SecureStore.setItemAsync('refreshToken', result.refreshToken);
+        setLoginDone(true);
+        accessToken = result.accessToken;
+      } else {
+        accessToken = (await SecureStore.getItemAsync('accessToken')) ?? '';
+      }
+
+      if (children.length > 0) {
+        await registerChildren(children, accessToken);
+      }
+
+      setStatus('done');
+      reset();
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : '오류가 발생했어요. 다시 시도해주세요.'
+      );
+      setStatus('error');
     }
   }, []);
+
+  useEffect(() => {
+    run();
+  }, [run]);
+
+  useEffect(() => {
+    if (status === 'done' && confettiRef.current) {
+      confettiRef.current.start();
+    }
+  }, [status]);
+
+  if (status === 'loading') {
+    return (
+      <View style={[styles.container, styles.centered]}>
+        <ActivityIndicator size="large" color={colors.primary[400]} />
+      </View>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <View style={[styles.container, styles.centered]}>
+        <Text style={styles.errorText}>{errorMessage}</Text>
+        <TouchableOpacity style={styles.retryButton} onPress={run} activeOpacity={0.7}>
+          <Text style={styles.retryButtonText}>다시 시도</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
 
   return (
     <View style={styles.container}>
@@ -85,6 +180,11 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.text.white,
   },
+  centered: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 20,
+  },
   content: {
     flex: 1,
     justifyContent: 'center',
@@ -131,5 +231,23 @@ const styles = StyleSheet.create({
   buttonWrapper: {
     alignSelf: 'stretch',
     paddingHorizontal: layout.screenPaddingHorizontal,
+  },
+  errorText: {
+    fontSize: 14,
+    fontFamily: fonts.medium,
+    color: colors.text.red,
+    textAlign: 'center',
+    paddingHorizontal: layout.screenPaddingHorizontal,
+  },
+  retryButton: {
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 8,
+    backgroundColor: colors.primary[400],
+  },
+  retryButtonText: {
+    fontSize: 14,
+    fontFamily: fonts.semiBold,
+    color: colors.text.white,
   },
 });

--- a/app/(auth)/register/notification.tsx
+++ b/app/(auth)/register/notification.tsx
@@ -10,15 +10,6 @@ import { NotificationType, NotificationOption } from '../../../src/types/notific
 
 const NOTIFICATION_OPTIONS: NotificationOption[] = [
   {
-    type: 'urgent',
-    title: '긴급 알림만',
-    description: '마감일 등 꼭 필요한 알림만 받아요',
-    iconName: 'alert-circle-outline',
-    iconColor: colors.text.red,
-    iconBg: colors.text.white,
-    iconBordered: true,
-  },
-  {
     type: 'important',
     title: '중요 알림',
     description: '마감일과 곧 확인이 필요한 내용을 받아요',
@@ -26,6 +17,15 @@ const NOTIFICATION_OPTIONS: NotificationOption[] = [
     iconColor: colors.secondary[600],
     iconBg: colors.secondary[100],
     badge: '추천',
+  },
+  {
+    type: 'urgent',
+    title: '긴급 알림만',
+    description: '마감일 등 꼭 필요한 알림만 받아요',
+    iconName: 'alert-circle-outline',
+    iconColor: colors.text.red,
+    iconBg: colors.text.white,
+    iconBordered: true,
   },
   {
     type: 'all',
@@ -95,7 +95,7 @@ const NotificationCard = ({ option, selected, onPress }: NotificationCardProps) 
 // ─── 메인 화면 ────────────────────────────────────────────────────────────────
 
 const RegisterNotificationScreen = () => {
-  const [selected, setSelected] = useState<NotificationType>('urgent');
+  const [selected, setSelected] = useState<NotificationType>('important');
 
   return (
     <View style={styles.container}>

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -105,3 +105,28 @@ export const verifyEmailCode = async (email: string, code: string): Promise<void
     throw wrapError(error);
   }
 };
+
+export interface SignupResult {
+  userId: number;
+  loginId: string;
+  email: string;
+  name: string;
+  phoneNumber: string;
+}
+
+export const signup = async (payload: {
+  name: string;
+  email: string;
+  loginId: string;
+  password: string;
+  passwordConfirm: string;
+  phoneNumber: string;
+  consentAgreed: boolean;
+}): Promise<SignupResult> => {
+  try {
+    const response = await apiClient.post('/api/v1/auth/signup', payload);
+    return response.data.result;
+  } catch (error) {
+    throw wrapError(error);
+  }
+};

--- a/src/api/child.ts
+++ b/src/api/child.ts
@@ -1,0 +1,63 @@
+import axios from 'axios';
+
+export class ChildApiError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string
+  ) {
+    super(message);
+    this.name = 'ChildApiError';
+  }
+}
+
+const wrapError = (error: unknown): Error => {
+  if (axios.isAxiosError(error) && error.response?.data?.code) {
+    return new ChildApiError(
+      error.response.data.code,
+      error.response.data.message ?? '알 수 없는 오류'
+    );
+  }
+  return error instanceof Error ? error : new Error(String(error));
+};
+
+const childApiClient = axios.create({
+  baseURL: 'https://43.202.191.103',
+  headers: { 'Content-Type': 'application/json' },
+  timeout: 10000,
+});
+
+export interface ChildPayload {
+  name: string;
+  schoolName: string;
+  schoolCode: string;
+  grade: number;
+  colorCode: string;
+}
+
+export interface ChildResult {
+  id: number;
+  name: string;
+  schoolName: string;
+  schoolCode: string;
+  grade: number;
+  colorCode: string;
+  createdAt: string;
+}
+
+export const registerChildren = async (
+  children: ChildPayload[],
+  accessToken: string
+): Promise<ChildResult[]> => {
+  try {
+    const results = await Promise.all(
+      children.map((child) =>
+        childApiClient.post<{ result: ChildResult }>('/api/v1/children', child, {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        })
+      )
+    );
+    return results.map((res) => res.data.result);
+  } catch (error) {
+    throw wrapError(error);
+  }
+};

--- a/src/api/child.ts
+++ b/src/api/child.ts
@@ -44,6 +44,20 @@ export interface ChildResult {
   createdAt: string;
 }
 
+export const registerChild = async (
+  child: ChildPayload,
+  accessToken: string
+): Promise<ChildResult> => {
+  try {
+    const response = await childApiClient.post<{ result: ChildResult }>('/api/v1/children', child, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    return response.data.result;
+  } catch (error) {
+    throw wrapError(error);
+  }
+};
+
 export const registerChildren = async (
   children: ChildPayload[],
   accessToken: string

--- a/src/store/registerStore.ts
+++ b/src/store/registerStore.ts
@@ -10,6 +10,7 @@ interface RegisterState {
   children: ChildPayload[];
   signupDone: boolean;
   loginDone: boolean;
+  registeredChildrenCount: number;
   setBasicInfo: (info: {
     loginId: string;
     password: string;
@@ -20,6 +21,7 @@ interface RegisterState {
   setChildren: (v: ChildPayload[]) => void;
   setSignupDone: (v: boolean) => void;
   setLoginDone: (v: boolean) => void;
+  incrementRegisteredChildrenCount: () => void;
   reset: () => void;
 }
 
@@ -32,13 +34,28 @@ const initialState = {
   children: [],
   signupDone: false,
   loginDone: false,
+  registeredChildrenCount: 0,
 };
 
 export const useRegisterStore = create<RegisterState>((set) => ({
   ...initialState,
-  setBasicInfo: (info) => set(info),
-  setChildren: (v) => set({ children: v }),
+  setBasicInfo: (info) =>
+    set((state) => {
+      const changed =
+        state.loginId !== info.loginId ||
+        state.password !== info.password ||
+        state.name !== info.name ||
+        state.email !== info.email ||
+        state.phoneNumber !== info.phoneNumber;
+      return {
+        ...info,
+        ...(changed ? { signupDone: false, loginDone: false } : {}),
+      };
+    }),
+  setChildren: (v) => set({ children: v, registeredChildrenCount: 0 }),
   setSignupDone: (v) => set({ signupDone: v }),
   setLoginDone: (v) => set({ loginDone: v }),
+  incrementRegisteredChildrenCount: () =>
+    set((state) => ({ registeredChildrenCount: state.registeredChildrenCount + 1 })),
   reset: () => set(initialState),
 }));

--- a/src/store/registerStore.ts
+++ b/src/store/registerStore.ts
@@ -1,0 +1,44 @@
+import { create } from 'zustand';
+import { ChildPayload } from '../api/child';
+
+interface RegisterState {
+  loginId: string;
+  password: string;
+  name: string;
+  email: string;
+  phoneNumber: string;
+  children: ChildPayload[];
+  signupDone: boolean;
+  loginDone: boolean;
+  setBasicInfo: (info: {
+    loginId: string;
+    password: string;
+    name: string;
+    email: string;
+    phoneNumber: string;
+  }) => void;
+  setChildren: (v: ChildPayload[]) => void;
+  setSignupDone: (v: boolean) => void;
+  setLoginDone: (v: boolean) => void;
+  reset: () => void;
+}
+
+const initialState = {
+  loginId: '',
+  password: '',
+  name: '',
+  email: '',
+  phoneNumber: '',
+  children: [],
+  signupDone: false,
+  loginDone: false,
+};
+
+export const useRegisterStore = create<RegisterState>((set) => ({
+  ...initialState,
+  setBasicInfo: (info) => set(info),
+  setChildren: (v) => set({ children: v }),
+  setSignupDone: (v) => set({ signupDone: v }),
+  setLoginDone: (v) => set({ loginDone: v }),
+  reset: () => set(initialState),
+}));

--- a/src/types/school.ts
+++ b/src/types/school.ts
@@ -2,4 +2,5 @@ export interface SchoolResult {
   name: string;
   address: string;
   type: string;
+  schoolCode?: string;
 }


### PR DESCRIPTION
## 📌 작업 내용

- 회원가입 API 연동 및 Zustand store 기반 플로우 상태 관리
- 자녀 등록 API 연동
- complete 화면에서 signup - login - registerChildren 순서 호출 및 SecureStore 토큰 저장
- 단계별 재시도 처리 (signupDone·loginDone 플래그로 이미 성공한 단계 건너뜀)
- 자녀 정보 입력 완성 여부 검증 (이름·학교·학년·색상 모두 입력 시 다음 버튼 활성화)
- 자녀 캘린더 색상 기본값 설정 (첫번째 색상)
- 알림 단계 카드 순서 변경 및 기본 선택값 수정 (중요 알림 최상단·기본값)

## 📷 스크린 샷

<img width="300" src="https://github.com/user-attachments/assets/0bce76b8-dc8e-44dd-8a7f-0e97da377e7c" />


## ⚠️ 참고 사항

- 자녀 등록 API에 토큰이 필요하나 signup 응답에 토큰이 없어, complete 화면에서 내부적으로 login을 호출해 토큰을 발급받은 후 자녀 등록을 진행합니다.

## 🔗 관련 이슈

Closes #25 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 등록 단계 간 양식 데이터 자동 저장으로 사용자 편의성 향상
  * 자녀 프로필 설정 시 이름, 학교, 학년, 색상 검증 추가
  * 보안 토큰 저장 및 로그인 완료 처리 기능 구현
  * 오류 발생 시 재시도 옵션 제공

* **개선사항**
  * 알림 기본 설정이 '중요'로 변경
  * 자녀 캘린더 색상에 기본값 자동 지정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->