### PR TITLE
✨ [Feature] 문서 스캔 화면 구현 (#27)

### DIFF
--- a/app/(auth)/register/language.tsx
+++ b/app/(auth)/register/language.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
-import { View, Text, Image, ScrollView, TouchableOpacity } from 'react-native';
+import { View, Text, Image, ScrollView } from 'react-native';
 import { router } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import StepHeader from '../../../src/components/common/StepHeader';
 import { PrimaryButton, SecondaryButton } from '../../../src/components/common/Button';
+import SelectionCard from '../../../src/components/common/SelectionCard';
 import colors from '../../../src/constants/colors';
 import styles from '../../../src/styles/register/language';
 import { LanguageType, LanguageOption } from '../../../src/types/language';
@@ -19,36 +20,6 @@ const LANGUAGE_OPTIONS: LanguageOption[] = [
   { type: 'zh', name: '中文', label: '중국어', flag: CNFlag },
 ];
 
-// ─── LanguageCard ─────────────────────────────────────────────────────────────
-
-interface LanguageCardProps {
-  option: LanguageOption;
-  selected: boolean;
-  onPress: () => void;
-}
-
-const LanguageCard = ({ option, selected, onPress }: LanguageCardProps) => (
-  <TouchableOpacity
-    style={[styles.card, selected && styles.cardSelected]}
-    onPress={onPress}
-    activeOpacity={0.8}
-  >
-    {selected && <View style={styles.selectedBar} />}
-    <View style={styles.flagWrapper}>
-      <Image source={option.flag} style={styles.flagImage} />
-    </View>
-
-    <View style={styles.cardContent}>
-      <Text style={styles.cardName}>{option.name}</Text>
-      <Text style={styles.cardLabel}>{option.label}</Text>
-    </View>
-
-    <View style={[styles.radio, selected && styles.radioSelected]} />
-  </TouchableOpacity>
-);
-
-// ─── 메인 화면 ────────────────────────────────────────────────────────────────
-
 const RegisterLanguageScreen = () => {
   const [selected, setSelected] = useState<LanguageType>('ko');
 
@@ -62,23 +33,29 @@ const RegisterLanguageScreen = () => {
         showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
       >
-        {/* 타이틀 */}
         <View style={styles.titleSection}>
           <Text style={styles.title}>사용할 언어를 선택해 주세요</Text>
           <Text style={styles.subtitle}>선택한 언어로 가정통신문을 번역하고 쉽게 설명해드려요</Text>
         </View>
 
-        {/* 언어 선택 */}
-        {LANGUAGE_OPTIONS.map((option) => (
-          <LanguageCard
-            key={option.type}
-            option={option}
-            selected={selected === option.type}
-            onPress={() => setSelected(option.type)}
-          />
-        ))}
+        <View style={styles.cardList}>
+          {LANGUAGE_OPTIONS.map((option) => (
+            <SelectionCard
+              key={option.type}
+              name={option.name}
+              label={option.label}
+              leftElement={
+                <View style={styles.flagWrapper}>
+                  <Image source={option.flag} style={styles.flagImage} />
+                </View>
+              }
+              selected={selected === option.type}
+              onPress={() => setSelected(option.type)}
+              size="lg"
+            />
+          ))}
+        </View>
 
-        {/* 안내 배너 + 버튼 */}
         <View style={styles.footer}>
           <View style={styles.banner}>
             <Ionicons name="settings" size={18} color={colors.text.primary} />

--- a/app/scan/camera.tsx
+++ b/app/scan/camera.tsx
@@ -1,0 +1,238 @@
+import { useRef, useState } from 'react';
+import { View, Text, Alert, TouchableOpacity, StyleSheet } from 'react-native';
+import { CameraView, useCameraPermissions } from 'expo-camera';
+import { router, useLocalSearchParams } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import * as ImagePicker from 'expo-image-picker';
+import Header from '../../src/components/common/Header';
+import ScanStepIndicator from '../../src/components/scan/ScanStepIndicator';
+import ScanHelpModal from '../../src/components/scan/ScanHelpModal';
+import ScanChildPill from '../../src/components/scan/ScanChildPill';
+import ScanCornerBrackets from '../../src/components/scan/ScanCornerBrackets';
+import colors from '../../src/constants/colors';
+import fonts from '../../src/constants/fonts';
+import { SCAN_FRAME_W, SCAN_FRAME_H, SCAN_DEFAULT_CHILD_COLOR } from '../../src/constants/scan';
+
+export default function ScanCameraScreen() {
+  const { childName, childColor } = useLocalSearchParams<{
+    childName: string;
+    childColor: string;
+  }>();
+  const [facing, setFacing] = useState<'front' | 'back'>('back');
+  const [helpVisible, setHelpVisible] = useState(false);
+  const [capturing, setCapturing] = useState(false);
+  const [permission, requestPermission] = useCameraPermissions();
+  const cameraRef = useRef<CameraView>(null);
+  const insets = useSafeAreaInsets();
+
+  const handleCapture = async () => {
+    if (!cameraRef.current || capturing) return;
+    setCapturing(true);
+    try {
+      const photo = await cameraRef.current.takePictureAsync({ quality: 1 });
+      if (photo) {
+        router.push({
+          pathname: '/scan/preview',
+          params: {
+            photoUri: photo.uri,
+            childName: childName ?? '',
+            childColor: childColor ?? '',
+            source: 'camera',
+          },
+        });
+        return;
+      }
+      setCapturing(false);
+    } catch {
+      Alert.alert('촬영 실패', '다시 시도해주세요.');
+      setCapturing(false);
+    }
+  };
+
+  const handleGallery = async () => {
+    try {
+      const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (status !== 'granted') {
+        Alert.alert('권한 필요', '갤러리 접근 권한이 필요해요.');
+        return;
+      }
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ['images'],
+        quality: 1,
+      });
+      if (!result.canceled) {
+        router.push({
+          pathname: '/scan/preview',
+          params: {
+            photoUri: result.assets[0].uri,
+            childName: childName ?? '',
+            childColor: childColor ?? '',
+            source: 'gallery',
+          },
+        });
+      }
+    } catch {
+      Alert.alert('오류', '갤러리를 불러올 수 없어요.');
+    }
+  };
+
+  if (!permission) return <View style={styles.screen} />;
+
+  if (!permission.granted) {
+    return (
+      <View style={styles.permissionScreen}>
+        <Ionicons name="camera-outline" size={40} color={colors.primary[400]} />
+        <Text style={styles.permissionText}>카메라 접근 권한이 필요해요</Text>
+        <TouchableOpacity
+          style={styles.permissionBtn}
+          onPress={requestPermission}
+          accessibilityLabel="카메라 권한 허용"
+          accessibilityRole="button"
+        >
+          <Text style={styles.permissionBtnText}>권한 허용하기</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  const hasChild = !!childName;
+
+  return (
+    <View style={styles.screen}>
+      <Header title="문서 스캔" onHelp={() => setHelpVisible(true)} />
+      <ScanStepIndicator currentStep={2} />
+
+      {hasChild && (
+        <ScanChildPill
+          name={childName}
+          color={childColor || SCAN_DEFAULT_CHILD_COLOR}
+          onChangePress={() => router.back()}
+        />
+      )}
+
+      <View style={styles.cameraWrapper}>
+        <CameraView ref={cameraRef} style={styles.camera} facing={facing} />
+        <ScanCornerBrackets />
+      </View>
+
+      <View style={[styles.bottomControls, { paddingBottom: insets.bottom + 16 }]}>
+        <TouchableOpacity
+          style={styles.sideButton}
+          onPress={handleGallery}
+          activeOpacity={0.8}
+          accessibilityLabel="갤러리에서 선택"
+          accessibilityRole="button"
+        >
+          <Ionicons name="image-outline" size={24} color={colors.text.white} />
+        </TouchableOpacity>
+
+        <View style={styles.captureRingShadow}>
+          <TouchableOpacity
+            style={styles.captureRing}
+            onPress={handleCapture}
+            disabled={capturing}
+            activeOpacity={0.85}
+            accessibilityLabel="사진 촬영"
+            accessibilityRole="button"
+          >
+            <View style={styles.captureButton} />
+          </TouchableOpacity>
+        </View>
+
+        <TouchableOpacity
+          style={styles.sideButton}
+          onPress={() => setFacing((f) => (f === 'back' ? 'front' : 'back'))}
+          activeOpacity={0.8}
+          accessibilityLabel="카메라 전환"
+          accessibilityRole="button"
+        >
+          <Ionicons name="camera-reverse-outline" size={24} color={colors.text.white} />
+        </TouchableOpacity>
+      </View>
+
+      <ScanHelpModal visible={helpVisible} onClose={() => setHelpVisible(false)} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.text.white,
+    paddingTop: 60,
+  },
+  cameraWrapper: {
+    width: SCAN_FRAME_W,
+    height: SCAN_FRAME_H,
+    alignSelf: 'center',
+    borderRadius: 16,
+    overflow: 'hidden',
+  },
+  camera: {
+    width: SCAN_FRAME_W,
+    height: SCAN_FRAME_H,
+  },
+  bottomControls: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 40,
+    paddingTop: 12,
+  },
+  sideButton: {
+    width: 54,
+    height: 54,
+    borderRadius: 27,
+    backgroundColor: colors.primary[400],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  captureRingShadow: {
+    shadowColor: colors.primary[400],
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.8,
+    shadowRadius: 12,
+    elevation: 6,
+    borderRadius: 38,
+  },
+  captureRing: {
+    width: 76,
+    height: 76,
+    borderRadius: 38,
+    borderWidth: 4,
+    borderColor: colors.primary[300],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  captureButton: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    backgroundColor: colors.primary[400],
+  },
+  permissionScreen: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.text.white,
+  },
+  permissionText: {
+    fontSize: 16,
+    fontFamily: fonts.medium,
+    color: colors.text.primary,
+  },
+  permissionBtn: {
+    backgroundColor: colors.primary[400],
+    borderRadius: 12,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    marginTop: 8,
+  },
+  permissionBtnText: {
+    fontSize: 15,
+    fontFamily: fonts.semiBold,
+    color: colors.text.white,
+  },
+});

--- a/app/scan/camera.tsx
+++ b/app/scan/camera.tsx
@@ -32,6 +32,7 @@ export default function ScanCameraScreen() {
     try {
       const photo = await cameraRef.current.takePictureAsync({ quality: 1 });
       if (photo) {
+        setCapturing(false);
         router.push({
           pathname: '/scan/preview',
           params: {

--- a/app/scan/index.tsx
+++ b/app/scan/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { View, Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
+import { View, Text, Alert, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
 import { router } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
@@ -21,35 +21,35 @@ const ScanChildSelectScreen = () => {
   const [selectedId, setSelectedId] = useState<string | null>(CHILDREN[0].id);
   const [helpVisible, setHelpVisible] = useState(false);
 
-  const handleCamera = async () => {
-    try {
-      const { status } = await ImagePicker.requestCameraPermissionsAsync();
-      if (status !== 'granted') return;
-      const result = await ImagePicker.launchCameraAsync({
-        mediaTypes: ['images'],
-        quality: 1,
-      });
-      if (!result.canceled) {
-        router.push('/scan/loading');
-      }
-    } catch {
-      // 카메라 실행 실패 시 무시
-    }
+  const selected = CHILDREN.find((c) => c.id === selectedId);
+  const childParams = {
+    childName: selected?.name ?? '',
+    childColor: selected?.color ?? '',
+  };
+
+  const handleCamera = () => {
+    router.push({ pathname: '/scan/camera', params: childParams });
   };
 
   const handleGallery = async () => {
     try {
       const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
-      if (status !== 'granted') return;
+      if (status !== 'granted') {
+        Alert.alert('권한 필요', '갤러리 접근 권한이 필요해요.');
+        return;
+      }
       const result = await ImagePicker.launchImageLibraryAsync({
         mediaTypes: ['images'],
         quality: 1,
       });
       if (!result.canceled) {
-        router.push('/scan/loading');
+        router.push({
+          pathname: '/scan/preview',
+          params: { photoUri: result.assets[0].uri, ...childParams, source: 'gallery' },
+        });
       }
     } catch {
-      // 갤러리 실행 실패 시 무시
+      Alert.alert('오류', '갤러리를 불러올 수 없어요.');
     }
   };
 
@@ -86,6 +86,8 @@ const ScanChildSelectScreen = () => {
             style={[styles.unknownCard, selectedId === null && styles.unknownCardSelected]}
             onPress={() => setSelectedId(null)}
             activeOpacity={0.8}
+            accessibilityLabel="어느 아이인지 모르겠어요"
+            accessibilityRole="button"
           >
             <View
               style={[

--- a/app/scan/index.tsx
+++ b/app/scan/index.tsx
@@ -1,0 +1,188 @@
+import { useState } from 'react';
+import { View, Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
+import { router } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import * as ImagePicker from 'expo-image-picker';
+import { PrimaryButton } from '../../src/components/common/Button';
+import Header from '../../src/components/common/Header';
+import SelectionCard from '../../src/components/common/SelectionCard';
+import ScanHelpModal from '../../src/components/scan/ScanHelpModal';
+import ScanStepIndicator from '../../src/components/scan/ScanStepIndicator';
+import colors from '../../src/constants/colors';
+import fonts from '../../src/constants/fonts';
+import layout from '../../src/constants/layout';
+
+const CHILDREN = [
+  { id: '1', name: '김첫째', grade: '초등학교 4학년', color: '#2CDA00' },
+  { id: '2', name: '김둘째', grade: '초등학교 1학년', color: '#FFCC2F' },
+];
+
+const ScanChildSelectScreen = () => {
+  const [selectedId, setSelectedId] = useState<string | null>(CHILDREN[0].id);
+  const [helpVisible, setHelpVisible] = useState(false);
+
+  const handleCamera = async () => {
+    try {
+      const { status } = await ImagePicker.requestCameraPermissionsAsync();
+      if (status !== 'granted') return;
+      const result = await ImagePicker.launchCameraAsync({
+        mediaTypes: ['images'],
+        quality: 1,
+      });
+      if (!result.canceled) {
+        router.push('/scan/loading');
+      }
+    } catch {
+      // 카메라 실행 실패 시 무시
+    }
+  };
+
+  const handleGallery = async () => {
+    try {
+      const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (status !== 'granted') return;
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ['images'],
+        quality: 1,
+      });
+      if (!result.canceled) {
+        router.push('/scan/loading');
+      }
+    } catch {
+      // 갤러리 실행 실패 시 무시
+    }
+  };
+
+  return (
+    <View style={styles.screen}>
+      <Header title="문서 스캔" onHelp={() => setHelpVisible(true)} />
+      <ScanStepIndicator currentStep={1} />
+
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={styles.titleSection}>
+          <Text style={styles.title}>누구의 가정통신문인가요?</Text>
+          <Text style={styles.subtitle}>아이를 선택하면 학년에 맞게 문서를 해석해드려요</Text>
+        </View>
+
+        <View style={styles.childList}>
+          {CHILDREN.map((child) => (
+            <SelectionCard
+              key={child.id}
+              name={child.name}
+              label={child.grade}
+              leftElement={<View style={[styles.avatar, { backgroundColor: child.color }]} />}
+              selected={selectedId === child.id}
+              onPress={() => setSelectedId(child.id)}
+              size="md"
+              indicatorColor={child.color}
+            />
+          ))}
+
+          <TouchableOpacity
+            style={[styles.unknownCard, selectedId === null && styles.unknownCardSelected]}
+            onPress={() => setSelectedId(null)}
+            activeOpacity={0.8}
+          >
+            <View
+              style={[
+                styles.unknownIconWrap,
+                selectedId === null && styles.unknownIconWrapSelected,
+              ]}
+            >
+              <Ionicons name="help" size={14} color={colors.text.white} />
+            </View>
+            <Text style={[styles.unknownText, selectedId === null && styles.unknownTextSelected]}>
+              어느 아이인지 모르겠어요
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.buttonGroup}>
+          <PrimaryButton label="카메라로 촬영하기" onPress={handleCamera} />
+          <PrimaryButton label="갤러리에서 선택하기" onPress={handleGallery} />
+        </View>
+      </ScrollView>
+
+      <ScanHelpModal visible={helpVisible} onClose={() => setHelpVisible(false)} />
+    </View>
+  );
+};
+
+export default ScanChildSelectScreen;
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.text.white,
+    paddingTop: 60,
+  },
+  scrollContent: {
+    paddingHorizontal: layout.screenPaddingHorizontal,
+    paddingBottom: layout.screenPaddingBottom,
+    gap: 24,
+  },
+  titleSection: {
+    gap: 8,
+  },
+  title: {
+    fontSize: 26,
+    fontFamily: fonts.bold,
+    color: colors.text.primary,
+    lineHeight: 36,
+  },
+  subtitle: {
+    fontSize: 14,
+    fontFamily: fonts.medium,
+    color: colors.text.secondary,
+    lineHeight: 22,
+  },
+  childList: {
+    gap: 20,
+  },
+  avatar: {
+    width: 35,
+    height: 35,
+    borderRadius: 25,
+  },
+  unknownCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderStyle: 'dashed',
+    borderColor: colors.primary[300],
+    borderRadius: 15,
+    height: 90,
+    gap: 10,
+  },
+  unknownCardSelected: {
+    backgroundColor: colors.primary[0],
+    borderColor: colors.primary[500],
+  },
+  unknownIconWrap: {
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    backgroundColor: colors.primary[200],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  unknownIconWrapSelected: {
+    backgroundColor: colors.primary[500],
+  },
+  unknownText: {
+    fontSize: 14,
+    fontFamily: fonts.medium,
+    color: colors.primary[300],
+  },
+  unknownTextSelected: {
+    color: colors.primary[500],
+  },
+  buttonGroup: {
+    gap: 12,
+  },
+});

--- a/app/scan/loading.tsx
+++ b/app/scan/loading.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useRef, useState } from 'react';
+import { View, Image, Text, Animated, ActivityIndicator, TouchableOpacity } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import Header from '../../src/components/common/Header';
+import ScanHelpModal from '../../src/components/scan/ScanHelpModal';
+import ScanStepIndicator from '../../src/components/scan/ScanStepIndicator';
+import { SCAN_FRAME_H } from '../../src/constants/scan';
+import colors from '../../src/constants/colors';
+import styles from '../../src/styles/scan/loading';
+
+const SCAN_DURATION = 20000;
+
+export default function ScanLoadingScreen() {
+  const { photoUri } = useLocalSearchParams<{
+    photoUri: string;
+  }>();
+
+  const insets = useSafeAreaInsets();
+  const progress = useRef(new Animated.Value(0)).current;
+  const scanLine = useRef(new Animated.Value(0)).current;
+
+  const frameOpacity = useRef(new Animated.Value(0)).current;
+  const checkmarkScale = useRef(new Animated.Value(0)).current;
+  const glowPulse = useRef(new Animated.Value(1)).current;
+  const textOpacity = useRef(new Animated.Value(0)).current;
+  const textSlide = useRef(new Animated.Value(20)).current;
+  const nextBtnOpacity = useRef(new Animated.Value(0)).current;
+  const nextBtnSlide = useRef(new Animated.Value(30)).current;
+
+  const glowAnimation = useRef<Animated.CompositeAnimation | null>(null);
+  const completionAnimation = useRef<Animated.CompositeAnimation | null>(null);
+  const [displayPercent, setDisplayPercent] = useState(0);
+  const [isComplete, setIsComplete] = useState(false);
+  const [helpVisible, setHelpVisible] = useState(false);
+
+  useEffect(() => {
+    const listenerId = progress.addListener(({ value }) => {
+      setDisplayPercent(Math.round(value * 100));
+    });
+
+    Animated.timing(progress, {
+      toValue: 1,
+      duration: SCAN_DURATION,
+      useNativeDriver: false,
+    }).start(({ finished }) => {
+      if (finished) setIsComplete(true);
+    });
+
+    const loopScanLine = () => {
+      scanLine.setValue(0);
+      Animated.timing(scanLine, {
+        toValue: 1,
+        duration: 2500,
+        useNativeDriver: true,
+      }).start(({ finished }) => {
+        if (finished) loopScanLine();
+      });
+    };
+    loopScanLine();
+
+    return () => {
+      progress.removeListener(listenerId);
+      progress.stopAnimation();
+      scanLine.stopAnimation();
+    };
+  }, [progress, scanLine]);
+
+  useEffect(() => {
+    if (!isComplete) return;
+
+    completionAnimation.current = Animated.parallel([
+      Animated.timing(frameOpacity, {
+        toValue: 1,
+        duration: 400,
+        useNativeDriver: true,
+      }),
+      Animated.sequence([
+        Animated.delay(200),
+        Animated.spring(checkmarkScale, {
+          toValue: 1,
+          tension: 50,
+          friction: 5,
+          useNativeDriver: true,
+        }),
+      ]),
+      Animated.sequence([
+        Animated.delay(550),
+        Animated.parallel([
+          Animated.timing(textOpacity, { toValue: 1, duration: 350, useNativeDriver: true }),
+          Animated.spring(textSlide, {
+            toValue: 0,
+            tension: 60,
+            friction: 8,
+            useNativeDriver: true,
+          }),
+        ]),
+      ]),
+      Animated.sequence([
+        Animated.delay(900),
+        Animated.parallel([
+          Animated.timing(nextBtnOpacity, { toValue: 1, duration: 400, useNativeDriver: true }),
+          Animated.spring(nextBtnSlide, {
+            toValue: 0,
+            tension: 55,
+            friction: 8,
+            useNativeDriver: true,
+          }),
+        ]),
+      ]),
+    ]);
+
+    completionAnimation.current.start(() => {
+      glowAnimation.current = Animated.loop(
+        Animated.sequence([
+          Animated.timing(glowPulse, { toValue: 1.12, duration: 950, useNativeDriver: true }),
+          Animated.timing(glowPulse, { toValue: 1.0, duration: 950, useNativeDriver: true }),
+        ])
+      );
+      glowAnimation.current.start();
+    });
+
+    return () => {
+      completionAnimation.current?.stop();
+      glowAnimation.current?.stop();
+    };
+  }, [
+    isComplete,
+    frameOpacity,
+    checkmarkScale,
+    glowPulse,
+    textOpacity,
+    textSlide,
+    nextBtnOpacity,
+    nextBtnSlide,
+  ]);
+
+  const progressWidth = progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['0%', '100%'],
+  });
+
+  const scanLineY = scanLine.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, SCAN_FRAME_H],
+  });
+
+  return (
+    <View style={styles.screen}>
+      <Header title="문서 스캔" onHelp={() => setHelpVisible(true)} />
+      <ScanStepIndicator currentStep={isComplete ? 4 : 3} />
+
+      {isComplete ? (
+        <Animated.View style={[styles.completionFrame, { opacity: frameOpacity }]}>
+          <Animated.View style={{ transform: [{ scale: glowPulse }] }}>
+            <Animated.View style={[styles.glowCircle, { transform: [{ scale: checkmarkScale }] }]}>
+              <Ionicons name="checkmark" size={44} color={colors.text.white} />
+            </Animated.View>
+          </Animated.View>
+          <Animated.Text
+            style={[
+              styles.completionText,
+              { opacity: textOpacity, transform: [{ translateY: textSlide }] },
+            ]}
+          >
+            스캔 완료!
+          </Animated.Text>
+        </Animated.View>
+      ) : (
+        <View style={styles.imageWrapper}>
+          {photoUri ? (
+            <Image source={{ uri: photoUri }} style={styles.image} resizeMode="cover" />
+          ) : (
+            <View style={styles.imagePlaceholder} />
+          )}
+          <Animated.View style={[styles.scanLine, { transform: [{ translateY: scanLineY }] }]} />
+        </View>
+      )}
+
+      <View style={styles.statusArea}>
+        <View style={styles.statusRow}>
+          {isComplete ? (
+            <View style={styles.doneIcon}>
+              <Ionicons name="checkmark" size={22} color={colors.text.white} />
+            </View>
+          ) : (
+            <ActivityIndicator size="large" color={colors.primary[400]} />
+          )}
+          <View style={styles.statusTexts}>
+            <Text style={styles.statusTitle}>
+              {isComplete ? '번역 및 요약을 완료했어요!' : '문서를 스캔 중이에요 ...'}
+            </Text>
+            {!isComplete && (
+              <Text style={styles.statusSubtitle}>텍스트와 레이아웃을 분석하고 있어요</Text>
+            )}
+          </View>
+          <Text style={styles.percentText}>{displayPercent}%</Text>
+        </View>
+
+        <View style={styles.progressTrack}>
+          <Animated.View style={[styles.progressFill, { width: progressWidth }]} />
+        </View>
+      </View>
+
+      {isComplete && (
+        <Animated.View
+          style={[
+            styles.nextBtnWrapper,
+            {
+              opacity: nextBtnOpacity,
+              transform: [{ translateY: nextBtnSlide }],
+              marginBottom: insets.bottom + 16,
+            },
+          ]}
+        >
+          <TouchableOpacity
+            style={styles.nextBtn}
+            activeOpacity={0.8}
+            accessibilityRole="button"
+            accessibilityLabel="다음으로"
+          >
+            <Text style={styles.nextBtnText}>다음으로 →</Text>
+          </TouchableOpacity>
+        </Animated.View>
+      )}
+      <ScanHelpModal visible={helpVisible} onClose={() => setHelpVisible(false)} />
+    </View>
+  );
+}

--- a/app/scan/loading.tsx
+++ b/app/scan/loading.tsx
@@ -219,6 +219,9 @@ export default function ScanLoadingScreen() {
             activeOpacity={0.8}
             accessibilityRole="button"
             accessibilityLabel="다음으로"
+            onPress={() => {
+              // TODO: API 연동 후 다음 화면으로 이동
+            }}
           >
             <Text style={styles.nextBtnText}>다음으로 →</Text>
           </TouchableOpacity>

--- a/app/scan/preview.tsx
+++ b/app/scan/preview.tsx
@@ -1,0 +1,118 @@
+import { View, Image, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { router, useLocalSearchParams } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import Header from '../../src/components/common/Header';
+import ScanStepIndicator from '../../src/components/scan/ScanStepIndicator';
+import ScanChildPill from '../../src/components/scan/ScanChildPill';
+import ScanCornerBrackets from '../../src/components/scan/ScanCornerBrackets';
+import colors from '../../src/constants/colors';
+import fonts from '../../src/constants/fonts';
+import layout from '../../src/constants/layout';
+import { SCAN_FRAME_W, SCAN_FRAME_H, SCAN_DEFAULT_CHILD_COLOR } from '../../src/constants/scan';
+
+export default function ScanPreviewScreen() {
+  const { photoUri, childName, childColor, source } = useLocalSearchParams<{
+    photoUri: string;
+    childName: string;
+    childColor: string;
+    source: 'camera' | 'gallery';
+  }>();
+  const insets = useSafeAreaInsets();
+
+  const hasChild = !!childName;
+  const retakeLabel = source === 'gallery' ? '다시 선택하기' : '다시 찍기';
+
+  return (
+    <View style={styles.screen}>
+      <Header title="문서 스캔" />
+      <ScanStepIndicator currentStep={2} />
+
+      {hasChild && (
+        <ScanChildPill name={childName} color={childColor || SCAN_DEFAULT_CHILD_COLOR} />
+      )}
+
+      <View style={styles.frameWrapper}>
+        <Image
+          source={{ uri: photoUri }}
+          style={styles.image}
+          resizeMode="cover"
+          accessibilityLabel="스캔할 문서 미리보기"
+        />
+        <ScanCornerBrackets />
+      </View>
+
+      <View style={[styles.buttons, { paddingBottom: insets.bottom + 16 }]}>
+        <TouchableOpacity
+          style={styles.retakeBtn}
+          onPress={() => router.back()}
+          activeOpacity={0.8}
+          accessibilityLabel={retakeLabel}
+          accessibilityRole="button"
+        >
+          <Text style={styles.retakeBtnText}>{retakeLabel}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.confirmBtn}
+          onPress={() => router.push('/scan/loading')}
+          activeOpacity={0.8}
+          accessibilityLabel="사용하기"
+          accessibilityRole="button"
+        >
+          <Text style={styles.confirmBtnText}>사용하기</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.text.white,
+    paddingTop: 60,
+  },
+  frameWrapper: {
+    width: SCAN_FRAME_W,
+    height: SCAN_FRAME_H,
+    alignSelf: 'center',
+    borderRadius: 16,
+    overflow: 'hidden',
+  },
+  image: {
+    width: SCAN_FRAME_W,
+    height: SCAN_FRAME_H,
+  },
+  buttons: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: layout.screenPaddingHorizontal,
+    gap: 12,
+    paddingTop: 16,
+  },
+  retakeBtn: {
+    flex: 1,
+    paddingVertical: 18,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+    alignItems: 'center',
+  },
+  retakeBtnText: {
+    fontSize: 15,
+    fontFamily: fonts.semiBold,
+    color: colors.text.secondary,
+  },
+  confirmBtn: {
+    flex: 1,
+    paddingVertical: 18,
+    borderRadius: 14,
+    backgroundColor: colors.primary[400],
+    alignItems: 'center',
+  },
+  confirmBtnText: {
+    fontSize: 15,
+    fontFamily: fonts.bold,
+    color: colors.text.white,
+  },
+});

--- a/app/scan/preview.tsx
+++ b/app/scan/preview.tsx
@@ -53,7 +53,12 @@ export default function ScanPreviewScreen() {
         </TouchableOpacity>
         <TouchableOpacity
           style={styles.confirmBtn}
-          onPress={() => router.push('/scan/loading')}
+          onPress={() =>
+            router.push({
+              pathname: '/scan/loading',
+              params: { photoUri, childName, childColor },
+            })
+          }
           activeOpacity={0.8}
           accessibilityLabel="사용하기"
           accessibilityRole="button"

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,0 +1,68 @@
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { router } from 'expo-router';
+import colors from '../../constants/colors';
+import fonts from '../../constants/fonts';
+import layout from '../../constants/layout';
+
+interface HeaderProps {
+  title: string;
+  onBack?: () => void;
+  onHelp?: () => void;
+}
+
+const Header = ({ title, onBack, onHelp }: HeaderProps) => (
+  <View style={styles.container}>
+    <TouchableOpacity
+      style={styles.iconButton}
+      onPress={onBack ?? (() => router.back())}
+      accessibilityRole="button"
+      accessibilityLabel="뒤로 가기"
+    >
+      <Ionicons name="arrow-back" size={16} color={colors.gray[300]} />
+    </TouchableOpacity>
+    <Text style={styles.title}>{title}</Text>
+    {onHelp ? (
+      <TouchableOpacity
+        style={styles.iconButton}
+        onPress={onHelp}
+        accessibilityRole="button"
+        accessibilityLabel="도움말"
+      >
+        <Ionicons name="help" size={16} color={colors.gray[300]} />
+      </TouchableOpacity>
+    ) : (
+      <View style={styles.iconSpacer} />
+    )}
+  </View>
+);
+
+export default Header;
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: layout.screenPaddingHorizontal,
+    paddingBottom: 32,
+  },
+  iconButton: {
+    width: 30,
+    height: 30,
+    borderRadius: 15,
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 18,
+    fontFamily: fonts.semiBold,
+    color: colors.text.primary,
+  },
+  iconSpacer: {
+    width: 30,
+    height: 30,
+  },
+});

--- a/src/components/common/SelectionCard.tsx
+++ b/src/components/common/SelectionCard.tsx
@@ -40,6 +40,8 @@ const SelectionCard = ({
       ]}
       onPress={onPress}
       activeOpacity={0.8}
+      accessibilityRole="button"
+      accessibilityLabel={name}
     >
       {selected && <View style={styles.selectedBar} />}
       {leftElement}

--- a/src/components/common/SelectionCard.tsx
+++ b/src/components/common/SelectionCard.tsx
@@ -1,0 +1,120 @@
+import type { ReactNode } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import colors from '../../constants/colors';
+import fonts from '../../constants/fonts';
+
+type CardSize = 'lg' | 'md' | 'sm';
+
+const SIZE_CONFIG = {
+  lg: { height: 90, paddingH: 22, nameSize: 20, labelSize: 16 },
+  md: { height: 90, paddingH: 22, nameSize: 18, labelSize: 16 },
+  sm: { height: 64, paddingH: 16, nameSize: 14, labelSize: 12 },
+} as const;
+
+interface SelectionCardProps {
+  name: string;
+  label: string;
+  leftElement: ReactNode;
+  selected: boolean;
+  onPress: () => void;
+  size?: CardSize;
+  indicatorColor?: string;
+}
+
+const SelectionCard = ({
+  name,
+  label,
+  leftElement,
+  selected,
+  onPress,
+  size = 'lg',
+  indicatorColor,
+}: SelectionCardProps) => {
+  const s = SIZE_CONFIG[size];
+  return (
+    <TouchableOpacity
+      style={[
+        styles.card,
+        { height: s.height, paddingHorizontal: s.paddingH },
+        selected && styles.cardSelected,
+      ]}
+      onPress={onPress}
+      activeOpacity={0.8}
+    >
+      {selected && <View style={styles.selectedBar} />}
+      {leftElement}
+      <View style={styles.content}>
+        <Text style={[styles.name, { fontSize: s.nameSize }]}>{name}</Text>
+        <Text style={[styles.label, { fontSize: s.labelSize }]}>{label}</Text>
+      </View>
+      {size === 'md' && indicatorColor && (
+        <View style={[styles.dot, { backgroundColor: indicatorColor }]} />
+      )}
+      <View style={[styles.radio, selected && styles.radioSelected]} />
+    </TouchableOpacity>
+  );
+};
+
+export default SelectionCard;
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.text.white,
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+    borderRadius: 15,
+    gap: 14,
+    overflow: 'hidden',
+  },
+  cardSelected: {
+    backgroundColor: colors.primary[0],
+    borderColor: colors.primary[400],
+    shadowColor: '#1F2A37',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.06,
+    shadowRadius: 6,
+    elevation: 3,
+  },
+  selectedBar: {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    bottom: 0,
+    width: 4,
+    backgroundColor: colors.primary[400],
+    borderTopLeftRadius: 15,
+    borderBottomLeftRadius: 15,
+  },
+  content: {
+    flex: 1,
+    gap: 2,
+  },
+  name: {
+    fontFamily: fonts.medium,
+    color: colors.text.primary,
+  },
+  label: {
+    fontFamily: fonts.medium,
+    color: colors.text.secondary,
+  },
+  radio: {
+    width: 26,
+    height: 26,
+    borderRadius: 13,
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+    backgroundColor: colors.text.white,
+  },
+  radioSelected: {
+    backgroundColor: colors.primary[0],
+    borderColor: colors.primary[400],
+    borderWidth: 7,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+});

--- a/src/components/common/TabBar.tsx
+++ b/src/components/common/TabBar.tsx
@@ -1,6 +1,7 @@
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import type { BottomTabBarProps } from '@react-navigation/bottom-tabs';
 import { Ionicons } from '@expo/vector-icons';
+import { router } from 'expo-router';
 import Svg, { Defs, RadialGradient, Stop, Circle } from 'react-native-svg';
 import colors from '../../constants/colors';
 import fonts from '../../constants/fonts';
@@ -52,7 +53,7 @@ const TabBar = ({ state, navigation, insets }: BottomTabBarProps) => (
             <TouchableOpacity
               key={tab.routeName}
               style={styles.scanWrapper}
-              onPress={onPress}
+              onPress={() => router.push('/scan')}
               activeOpacity={0.85}
             >
               <View style={styles.scanButton}>

--- a/src/components/home/ScanBanner.tsx
+++ b/src/components/home/ScanBanner.tsx
@@ -16,7 +16,7 @@ const ScanBanner = () => (
     <TouchableOpacity
       style={styles.button}
       activeOpacity={0.8}
-      onPress={() => router.push('/(tabs)/scan')}
+      onPress={() => router.push('/scan')}
     >
       <Text style={styles.buttonText}>지금 스캔 →</Text>
     </TouchableOpacity>

--- a/src/components/scan/ScanChildPill.tsx
+++ b/src/components/scan/ScanChildPill.tsx
@@ -1,0 +1,65 @@
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import colors from '../../constants/colors';
+import fonts from '../../constants/fonts';
+
+interface ScanChildPillProps {
+  name: string;
+  color: string;
+  onChangePress?: () => void;
+}
+
+const ScanChildPill = ({ name, color, onChangePress }: ScanChildPillProps) => (
+  <View style={styles.pill}>
+    <View style={[styles.dot, { backgroundColor: color }]} />
+    <Text style={styles.text}>
+      <Text style={styles.name}>{name}</Text>
+      {' 의 가정통신문'}
+    </Text>
+    {onChangePress && (
+      <TouchableOpacity
+        onPress={onChangePress}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        accessibilityLabel="아이 변경"
+        accessibilityRole="button"
+      >
+        <Text style={styles.change}>변경</Text>
+      </TouchableOpacity>
+    )}
+  </View>
+);
+
+export default ScanChildPill;
+
+const styles = StyleSheet.create({
+  pill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'center',
+    backgroundColor: colors.primary[400],
+    borderRadius: 20,
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+    gap: 6,
+    marginBottom: 16,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  text: {
+    fontSize: 13,
+    fontFamily: fonts.medium,
+    color: colors.text.white,
+  },
+  name: {
+    fontFamily: fonts.semiBold,
+  },
+  change: {
+    fontSize: 13,
+    fontFamily: fonts.semiBold,
+    color: colors.text.white,
+    textDecorationLine: 'underline',
+    marginLeft: 2,
+  },
+});

--- a/src/components/scan/ScanCornerBrackets.tsx
+++ b/src/components/scan/ScanCornerBrackets.tsx
@@ -1,0 +1,49 @@
+import { View, StyleSheet } from 'react-native';
+import colors from '../../constants/colors';
+import { SCAN_CORNER, SCAN_THICK } from '../../constants/scan';
+
+const ScanCornerBrackets = () => (
+  <>
+    <View style={[styles.corner, { top: 16, left: 16 }]} pointerEvents="none">
+      <View style={[styles.cornerH, { top: 0 }]} />
+      <View style={[styles.cornerV, { top: 0, left: 0 }]} />
+    </View>
+    <View style={[styles.corner, { top: 16, right: 16 }]} pointerEvents="none">
+      <View style={[styles.cornerH, { top: 0 }]} />
+      <View style={[styles.cornerV, { top: 0, right: 0 }]} />
+    </View>
+    <View style={[styles.corner, { bottom: 16, left: 16 }]} pointerEvents="none">
+      <View style={[styles.cornerH, { bottom: 0 }]} />
+      <View style={[styles.cornerV, { bottom: 0, left: 0 }]} />
+    </View>
+    <View style={[styles.corner, { bottom: 16, right: 16 }]} pointerEvents="none">
+      <View style={[styles.cornerH, { bottom: 0 }]} />
+      <View style={[styles.cornerV, { bottom: 0, right: 0 }]} />
+    </View>
+  </>
+);
+
+export default ScanCornerBrackets;
+
+const styles = StyleSheet.create({
+  corner: {
+    position: 'absolute',
+    width: SCAN_CORNER,
+    height: SCAN_CORNER,
+    zIndex: 10,
+  },
+  cornerH: {
+    position: 'absolute',
+    width: SCAN_CORNER,
+    height: SCAN_THICK,
+    backgroundColor: colors.text.white,
+    borderRadius: 2,
+  },
+  cornerV: {
+    position: 'absolute',
+    width: SCAN_THICK,
+    height: SCAN_CORNER,
+    backgroundColor: colors.text.white,
+    borderRadius: 2,
+  },
+});

--- a/src/components/scan/ScanHelpModal.tsx
+++ b/src/components/scan/ScanHelpModal.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useRef, useState } from 'react';
+import { View, Text, TouchableOpacity, Modal, Pressable, Animated, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { PrimaryButton } from '../common/Button';
+import colors from '../../constants/colors';
+import fonts from '../../constants/fonts';
+import layout from '../../constants/layout';
+
+const HELP_ITEMS = [
+  {
+    icon: 'person' as const,
+    bg: colors.primary[100],
+    iconColor: colors.primary[500],
+    title: '아이를 먼저 선택해 주세요',
+    desc: '학년에 맞게 문서를 더 정확하게 해석해 드려요',
+  },
+  {
+    icon: 'camera' as const,
+    bg: colors.gray[100],
+    iconColor: colors.gray[300],
+    title: '가정통신문을 촬영하거나 선택해 주세요',
+    desc: '글자가 잘 보이도록 평평하게 펴서 찍어주세요',
+  },
+  {
+    icon: 'sparkles' as const,
+    bg: colors.secondary[200],
+    iconColor: colors.secondary[600],
+    title: 'AI가 자동으로 분석해요',
+    desc: '번역 · 요약 · 체크리스트까지 한 번에 만들어드려요',
+  },
+];
+
+interface ScanHelpModalProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+const SHEET_HEIGHT = 420;
+const returnTrue = () => true;
+
+const ScanHelpModal = ({ visible, onClose }: ScanHelpModalProps) => {
+  const [show, setShow] = useState(false);
+  const opacity = useRef(new Animated.Value(0)).current;
+  const translateY = useRef(new Animated.Value(SHEET_HEIGHT)).current;
+
+  useEffect(() => {
+    if (visible) {
+      opacity.setValue(0);
+      translateY.setValue(SHEET_HEIGHT);
+      setShow(true);
+      Animated.parallel([
+        Animated.timing(opacity, {
+          toValue: 1,
+          duration: 250,
+          useNativeDriver: true,
+        }),
+        Animated.spring(translateY, {
+          toValue: 0,
+          bounciness: 0,
+          speed: 8,
+          useNativeDriver: true,
+        }),
+      ]).start();
+    } else if (show) {
+      Animated.parallel([
+        Animated.timing(opacity, {
+          toValue: 0,
+          duration: 200,
+          useNativeDriver: true,
+        }),
+        Animated.timing(translateY, {
+          toValue: SHEET_HEIGHT,
+          duration: 220,
+          useNativeDriver: true,
+        }),
+      ]).start(() => setShow(false));
+    }
+  }, [visible, opacity, translateY]);
+
+  return (
+    <Modal visible={show} transparent animationType="none" onRequestClose={onClose}>
+      <Animated.View style={[styles.backdrop, { opacity }]}>
+        <Pressable
+          style={StyleSheet.absoluteFill}
+          onPress={onClose}
+          accessibilityLabel="모달 닫기"
+        />
+      </Animated.View>
+
+      <Animated.View style={[styles.sheetWrap, { transform: [{ translateY }] }]}>
+        <View style={styles.sheet} onStartShouldSetResponder={returnTrue}>
+          <View style={styles.header}>
+            <Text style={styles.title}>스캔 이용 방법</Text>
+            <TouchableOpacity
+              onPress={onClose}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              accessibilityLabel="닫기"
+              accessibilityRole="button"
+            >
+              <Ionicons name="close" size={20} color={colors.gray[300]} />
+            </TouchableOpacity>
+          </View>
+
+          <View style={styles.list}>
+            {HELP_ITEMS.map((item) => (
+              <View key={item.title} style={styles.item}>
+                <View style={[styles.iconWrap, { backgroundColor: item.bg }]}>
+                  <Ionicons name={item.icon} size={18} color={item.iconColor} />
+                </View>
+                <View style={styles.itemContent}>
+                  <Text style={styles.itemTitle}>{item.title}</Text>
+                  <Text style={styles.itemDesc}>{item.desc}</Text>
+                </View>
+              </View>
+            ))}
+          </View>
+
+          <PrimaryButton label="확인했어요" onPress={onClose} />
+        </View>
+      </Animated.View>
+    </Modal>
+  );
+};
+
+export default ScanHelpModal;
+
+const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+  },
+  sheetWrap: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+  },
+  sheet: {
+    backgroundColor: colors.text.white,
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    paddingHorizontal: layout.screenPaddingHorizontal,
+    paddingTop: 24,
+    paddingBottom: 36,
+    gap: 24,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  title: {
+    fontSize: 18,
+    fontFamily: fonts.bold,
+    color: colors.text.primary,
+  },
+  list: {
+    gap: 20,
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 14,
+  },
+  iconWrap: {
+    width: 40,
+    height: 40,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  itemContent: {
+    flex: 1,
+    gap: 4,
+  },
+  itemTitle: {
+    fontSize: 14,
+    fontFamily: fonts.semiBold,
+    color: colors.text.primary,
+  },
+  itemDesc: {
+    fontSize: 13,
+    fontFamily: fonts.medium,
+    color: colors.text.secondary,
+    lineHeight: 20,
+  },
+});

--- a/src/components/scan/ScanHelpModal.tsx
+++ b/src/components/scan/ScanHelpModal.tsx
@@ -73,9 +73,11 @@ const ScanHelpModal = ({ visible, onClose }: ScanHelpModalProps) => {
           duration: 220,
           useNativeDriver: true,
         }),
-      ]).start(() => setShow(false));
+      ]).start(({ finished }) => {
+        if (finished) setShow(false);
+      });
     }
-  }, [visible, opacity, translateY]);
+  }, [visible, show, opacity, translateY]);
 
   return (
     <Modal visible={show} transparent animationType="none" onRequestClose={onClose}>

--- a/src/components/scan/ScanStepIndicator.tsx
+++ b/src/components/scan/ScanStepIndicator.tsx
@@ -17,7 +17,7 @@ const ScanStepIndicator = ({ currentStep, totalSteps = 4 }: ScanStepIndicatorPro
       const isActive = step === currentStep;
       return (
         <View key={step} style={styles.item}>
-          {i > 0 && <View style={[styles.line, isCompleted && styles.lineActive]} />}
+          {i > 0 && <View style={[styles.line, (isCompleted || isActive) && styles.lineActive]} />}
           <View style={isActive ? styles.activeRing : styles.ringPlaceholder}>
             <View
               style={[

--- a/src/components/scan/ScanStepIndicator.tsx
+++ b/src/components/scan/ScanStepIndicator.tsx
@@ -1,0 +1,106 @@
+import { View, Text, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import colors from '../../constants/colors';
+import fonts from '../../constants/fonts';
+import layout from '../../constants/layout';
+
+interface ScanStepIndicatorProps {
+  currentStep: number;
+  totalSteps?: number;
+}
+
+const ScanStepIndicator = ({ currentStep, totalSteps = 4 }: ScanStepIndicatorProps) => (
+  <View style={styles.container}>
+    {Array.from({ length: totalSteps }, (_, i) => {
+      const step = i + 1;
+      const isCompleted = step < currentStep;
+      const isActive = step === currentStep;
+      return (
+        <View key={step} style={styles.item}>
+          {i > 0 && <View style={[styles.line, isCompleted && styles.lineActive]} />}
+          <View style={isActive ? styles.activeRing : styles.ringPlaceholder}>
+            <View
+              style={[
+                styles.circle,
+                isCompleted && styles.circleCompleted,
+                isActive && styles.circleActive,
+              ]}
+            >
+              {isCompleted ? (
+                <Ionicons name="checkmark" size={13} color={colors.text.white} />
+              ) : (
+                <Text style={styles.number}>{step}</Text>
+              )}
+            </View>
+          </View>
+        </View>
+      );
+    })}
+  </View>
+);
+
+export default ScanStepIndicator;
+
+const CIRCLE_SIZE = 24;
+const RING_SIZE = CIRCLE_SIZE + 8;
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: layout.screenPaddingHorizontal,
+    paddingBottom: 28,
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  line: {
+    width: 52,
+    height: 2,
+    borderRadius: 1,
+    backgroundColor: colors.primary[100],
+  },
+  lineActive: {
+    backgroundColor: colors.primary[400],
+  },
+  ringPlaceholder: {
+    width: RING_SIZE,
+    height: RING_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  activeRing: {
+    width: RING_SIZE,
+    height: RING_SIZE,
+    borderRadius: RING_SIZE / 2,
+    backgroundColor: colors.primary[100],
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: colors.primary[400],
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.5,
+    shadowRadius: 6,
+    elevation: 12,
+  },
+  circle: {
+    width: CIRCLE_SIZE,
+    height: CIRCLE_SIZE,
+    borderRadius: CIRCLE_SIZE / 2,
+    backgroundColor: colors.primary[200],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  circleCompleted: {
+    backgroundColor: colors.primary[400],
+  },
+  circleActive: {
+    backgroundColor: colors.primary[400],
+  },
+  number: {
+    fontSize: 11,
+    fontFamily: fonts.semiBold,
+    color: colors.text.white,
+  },
+});

--- a/src/constants/scan.ts
+++ b/src/constants/scan.ts
@@ -1,0 +1,9 @@
+import { Dimensions } from 'react-native';
+
+const { width: SCREEN_W } = Dimensions.get('window');
+
+export const SCAN_FRAME_W = SCREEN_W - 40;
+export const SCAN_FRAME_H = SCAN_FRAME_W * 1.35;
+export const SCAN_CORNER = 28;
+export const SCAN_THICK = 4;
+export const SCAN_DEFAULT_CHILD_COLOR = '#2CDA00';

--- a/src/styles/register/language.ts
+++ b/src/styles/register/language.ts
@@ -35,40 +35,10 @@ const styles = StyleSheet.create({
     lineHeight: 22,
   },
 
-  // 언어 선택 카드
-  card: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: colors.text.white,
-    borderWidth: 1,
-    borderColor: colors.gray[200],
-    borderRadius: 15,
-    height: 90,
-    paddingHorizontal: 22,
-    gap: 14,
-    marginBottom: 10,
-    overflow: 'hidden',
+  cardList: {
+    gap: 15,
   },
-  cardSelected: {
-    backgroundColor: colors.primary[0],
-    borderColor: colors.primary[400],
-    shadowColor: '#1F2A37',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.06,
-    shadowRadius: 6,
-    elevation: 3,
-  },
-  selectedBar: {
-    position: 'absolute',
-    left: 0,
-    top: 0,
-    bottom: 0,
-    width: 4,
-    backgroundColor: colors.primary[400],
-    borderTopLeftRadius: 15,
-    borderBottomLeftRadius: 15,
-  },
-  // 국기 이미지
+
   flagWrapper: {
     width: 50,
     height: 50,
@@ -79,36 +49,6 @@ const styles = StyleSheet.create({
     width: 50,
     height: 50,
   },
-  // 카드 텍스트
-  cardContent: {
-    flex: 1,
-    gap: 2,
-  },
-  cardName: {
-    fontSize: 20,
-    fontFamily: fonts.medium,
-    color: colors.text.primary,
-  },
-  cardLabel: {
-    fontSize: 16,
-    fontFamily: fonts.medium,
-    color: colors.text.secondary,
-  },
-  // 라디오 버튼
-  radio: {
-    width: 26,
-    height: 26,
-    borderRadius: 13,
-    borderWidth: 1,
-    borderColor: colors.gray[200],
-    backgroundColor: colors.text.white,
-  },
-  radioSelected: {
-    backgroundColor: colors.primary[0],
-    borderColor: colors.primary[400],
-    borderWidth: 7,
-  },
-
   footer: {
     marginTop: 16,
     gap: 16,

--- a/src/styles/scan/loading.ts
+++ b/src/styles/scan/loading.ts
@@ -1,0 +1,146 @@
+import { StyleSheet } from 'react-native';
+import colors from '../../constants/colors';
+import fonts from '../../constants/fonts';
+import layout from '../../constants/layout';
+import { SCAN_FRAME_W, SCAN_FRAME_H } from '../../constants/scan';
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.text.white,
+    paddingTop: 60,
+  },
+  imageWrapper: {
+    width: SCAN_FRAME_W,
+    height: SCAN_FRAME_H,
+    alignSelf: 'center',
+    borderRadius: 16,
+    overflow: 'hidden',
+  },
+  image: {
+    width: SCAN_FRAME_W,
+    height: SCAN_FRAME_H,
+  },
+  imagePlaceholder: {
+    width: SCAN_FRAME_W,
+    height: SCAN_FRAME_H,
+    backgroundColor: colors.gray[100],
+  },
+  scanLine: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 3,
+    backgroundColor: colors.primary[400],
+    opacity: 0.85,
+    shadowColor: colors.primary[300],
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 1,
+    shadowRadius: 6,
+    elevation: 6,
+  },
+  completionFrame: {
+    width: SCAN_FRAME_W,
+    height: SCAN_FRAME_H,
+    alignSelf: 'center',
+    borderRadius: 16,
+    backgroundColor: '#111111',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 20,
+  },
+  glowCircle: {
+    width: 90,
+    height: 90,
+    borderRadius: 45,
+    backgroundColor: colors.primary[400],
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: colors.primary[300],
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 1,
+    shadowRadius: 28,
+    elevation: 20,
+  },
+  completionText: {
+    fontSize: 20,
+    fontFamily: fonts.bold,
+    color: colors.text.white,
+  },
+  statusArea: {
+    marginHorizontal: layout.screenPaddingHorizontal,
+    marginTop: 20,
+    padding: 20,
+    gap: 14,
+    backgroundColor: colors.text.white,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: colors.gray[100],
+    shadowColor: colors.gray[300],
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.06,
+    shadowRadius: 8,
+    elevation: 3,
+  },
+  statusRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  statusTexts: {
+    flex: 1,
+  },
+  statusTitle: {
+    fontSize: 15,
+    fontFamily: fonts.semiBold,
+    color: colors.text.primary,
+  },
+  statusSubtitle: {
+    fontSize: 13,
+    fontFamily: fonts.regular,
+    color: colors.text.secondary,
+    marginTop: 2,
+  },
+  percentText: {
+    fontSize: 22,
+    fontFamily: fonts.bold,
+    color: colors.primary[400],
+  },
+  doneIcon: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: colors.primary[400],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  progressTrack: {
+    height: 6,
+    backgroundColor: colors.gray[100],
+    borderRadius: 3,
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: 6,
+    backgroundColor: colors.primary[400],
+    borderRadius: 3,
+  },
+  nextBtnWrapper: {
+    marginHorizontal: layout.screenPaddingHorizontal,
+    marginTop: 16,
+  },
+  nextBtn: {
+    paddingVertical: 18,
+    borderRadius: 16,
+    backgroundColor: colors.primary[400],
+    alignItems: 'center',
+  },
+  nextBtnText: {
+    fontSize: 16,
+    fontFamily: fonts.bold,
+    color: colors.text.white,
+  },
+});
+
+export default styles;


### PR DESCRIPTION
## 📌 작업 내용

- 스캔 플로우 전체 화면 구현 (1~4단계)
  - **1단계** — 자녀 선택 화면 (`/scan`) 및 도움말 모달
  - **2단계** — 커스텀 카메라 화면 (`/scan/camera`), 촬영 및 갤러리 선택 지원
  - **3단계** — 사진 미리보기 화면 (`/scan/preview`), 다시 찍기/사용하기 버튼
  - **4단계** — 스캔 로딩 화면 (`/scan/loading`), 20초 진행률 애니메이션 및 완료 상태 전환
- 스캔 공통 상수(`SCAN_FRAME_W`, `SCAN_FRAME_H` 등) 및 공통 UI 컴포넌트 추가 (`ScanStepIndicator`, `ScanCornerBrackets`, `ScanChildPill`)
- 스캔 버튼 라우팅 `/scan`으로 연결

## 📷 스크린 샷

| 1단계 자녀 선택 | 도움말 모달 | 2단계 카메라 |
|---|---|---|
| <img width="180" alt="Screenshot_1777749475" src="https://github.com/user-attachments/assets/e61431ef-e479-4d30-8ac1-61dad8816d80" /> | <img width="180" alt="Screenshot_1777749487" src="https://github.com/user-attachments/assets/5ed5be1c-5995-4ec3-9676-50506239891d" /> | <img width="180" alt="Screenshot_1777749497" src="https://github.com/user-attachments/assets/21881d48-7644-48f2-ad0e-12bbadba3c6f" /> |

| 3단계 미리보기 | 4단계 로딩 | 완료 상태 |
|---|---|---|
| <img width="180" alt="Screenshot_1777749503" src="https://github.com/user-attachments/assets/b859bdaf-7b31-4694-8a27-6f57ba3e09d1" /> | <img width="180" alt="Screenshot_1777749522" src="https://github.com/user-attachments/assets/41f34da3-b318-4ad8-b92d-dd2d95674a2c" /> | <img width="180" alt="Screenshot_1777749526" src="https://github.com/user-attachments/assets/9b453b70-2b02-4553-bbbd-c917244f09fc" /> |


## ⚠️ 참고 사항

- 완료 후 "다음으로 →" 버튼 `onPress` 미연결 — API 연동 시 추가 예정
- 현재 자녀 목록은 하드코딩 (`CHILDREN` 배열) — API 연동 시 교체 예정

## 🔗 관련 이슈

Closes #27


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 문서 스캔 워크플로우 추가 (카메라 촬영 및 갤러리 이미지 선택 지원)
  * 스캔할 자녀 선택 기능
  * 스캔 이미지 미리보기 및 재촬영 옵션
  * 스캔 진행 상황 표시 및 완료 애니메이션

* **개선**
  * 언어 선택 화면 UI 개선
  * 스캔 탭 네비게이션 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->