### PR TITLE
✨ [Feature] 캘린더 화면 구현 (#33)

### DIFF
--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -1,25 +1,308 @@
-import { View, Text, StyleSheet } from 'react-native';
+import { useState, useMemo, useRef } from 'react';
+import { View, Text, ScrollView, TouchableOpacity } from 'react-native';
+import { Ionicons, FontAwesome5 } from '@expo/vector-icons';
+import { router } from 'expo-router';
 import colors from '../../src/constants/colors';
-import fonts from '../../src/constants/fonts';
+import { MOCK_CAL_CHILDREN, MOCK_EVENTS } from '../../src/mock/calendar';
+import type { CalendarEvent } from '../../src/mock/calendar';
+import styles from '../../src/styles/calendar/calendar';
+import EventCard from '../../src/components/calendar/EventCard';
+import WeekCalendar from '../../src/components/calendar/WeekCalendar';
+import MonthCalendar from '../../src/components/calendar/MonthCalendar';
 
-const CalendarScreen = () => (
-  <View style={styles.container}>
-    <Text style={styles.text}>calendar</Text>
-  </View>
-);
+const todayDate = new Date();
+const today = `${todayDate.getFullYear()}-${String(todayDate.getMonth() + 1).padStart(2, '0')}-${String(todayDate.getDate()).padStart(2, '0')}`;
+
+const DAY_NAMES = ['일', '월', '화', '수', '목', '금', '토'];
+
+const calcDDay = (dateStr: string): number => {
+  const base = new Date();
+  base.setHours(0, 0, 0, 0);
+  const [year, month, day] = dateStr.split('-').map(Number);
+  const target = new Date(year, month - 1, day);
+  return Math.round((target.getTime() - base.getTime()) / (1000 * 60 * 60 * 24));
+};
+
+const formatDayLabel = (dateStr: string) => {
+  const [, month, day] = dateStr.split('-');
+  return `${parseInt(month, 10)}월 ${parseInt(day, 10)}일`;
+};
+
+const formatWeekDateHeader = (dateStr: string) => {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  const d = new Date(year, month - 1, day);
+  return `${month}월 ${day}일 (${DAY_NAMES[d.getDay()]})`;
+};
+
+const CalendarScreen = () => {
+  const [selectedChildId, setSelectedChildId] = useState<string>('all');
+  const [selectedDate, setSelectedDate] = useState<string>(today);
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [events, setEvents] = useState<CalendarEvent[]>(MOCK_EVENTS);
+  const [isWeekMode, setIsWeekMode] = useState<boolean>(true);
+  const [weekOffset, setWeekOffset] = useState<number>(0);
+  const [calendarMonth, setCalendarMonth] = useState({
+    year: todayDate.getFullYear(),
+    month: todayDate.getMonth(),
+  });
+
+  const weekScrollRef = useRef<ScrollView>(null);
+  const weekOffsetRef = useRef(weekOffset);
+  weekOffsetRef.current = weekOffset;
+  const todayGroupY = useRef<number | undefined>(undefined);
+
+  const filteredByChild = useMemo(
+    () => events.filter((e) => selectedChildId === 'all' || e.childId === selectedChildId),
+    [events, selectedChildId]
+  );
+
+  const dayEvents = useMemo(
+    () => filteredByChild.filter((e) => e.date === selectedDate),
+    [filteredByChild, selectedDate]
+  );
+
+  const markedDates = useMemo(() => {
+    const marks: Record<string, { dots: { key: string; color: string }[] }> = {};
+    filteredByChild.forEach((event) => {
+      if (!marks[event.date]) marks[event.date] = { dots: [] };
+      if (!marks[event.date].dots.find((d) => d.key === event.childId)) {
+        marks[event.date].dots.push({ key: event.childId, color: event.calendarColor });
+      }
+    });
+    return marks;
+  }, [filteredByChild]);
+
+  const weekDates = useMemo(() => {
+    const d = new Date();
+    const dayOfWeek = d.getDay();
+    d.setDate(d.getDate() - dayOfWeek + weekOffset * 7);
+    d.setHours(0, 0, 0, 0);
+    const sunDate = d.getDate();
+    return Array.from({ length: 7 }, (_, i) => {
+      const date = new Date(d);
+      date.setDate(sunDate + i);
+      return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+    });
+  }, [weekOffset]);
+
+  const weekEventGroups = useMemo(() => {
+    const dateSet = new Set(weekDates);
+    const sorted = filteredByChild
+      .filter((e) => dateSet.has(e.date))
+      .sort((a, b) => {
+        if (a.date !== b.date) return a.date < b.date ? -1 : 1;
+        return calcDDay(a.date) - calcDDay(b.date);
+      });
+    const groups: { date: string; events: CalendarEvent[] }[] = [];
+    sorted.forEach((event) => {
+      const last = groups[groups.length - 1];
+      if (last && last.date === event.date) {
+        last.events.push(event);
+      } else {
+        groups.push({ date: event.date, events: [event] });
+      }
+    });
+    return groups;
+  }, [filteredByChild, weekDates]);
+
+  const toggleExpand = (id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const toggleCheck = (eventId: string, checkId: string) => {
+    setEvents((prev) =>
+      prev.map((e) =>
+        e.id !== eventId
+          ? e
+          : {
+              ...e,
+              checkList: e.checkList.map((c) => (c.id === checkId ? { ...c, done: !c.done } : c)),
+            }
+      )
+    );
+  };
+
+  const handleToggleMode = () => {
+    setIsWeekMode((prev) => !prev);
+    setExpandedIds(new Set());
+  };
+
+  const handlePrevMonth = () => {
+    setCalendarMonth(({ year, month }) => {
+      if (month === 0) return { year: year - 1, month: 11 };
+      return { year, month: month - 1 };
+    });
+  };
+
+  const handleNextMonth = () => {
+    setCalendarMonth(({ year, month }) => {
+      if (month === 11) return { year: year + 1, month: 0 };
+      return { year, month: month + 1 };
+    });
+  };
+
+  return (
+    <View style={styles.container}>
+      {/* 헤더 */}
+      <View style={styles.header}>
+        <TouchableOpacity
+          style={styles.iconButton}
+          onPress={() => router.back()}
+          accessibilityRole="button"
+        >
+          <Ionicons name="arrow-back" size={16} color={colors.gray[300]} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>캘린더</Text>
+        <TouchableOpacity
+          style={[styles.iconButton, styles.calendarIconButton]}
+          onPress={handleToggleMode}
+          accessibilityRole="button"
+        >
+          <FontAwesome5
+            name={isWeekMode ? 'calendar-alt' : 'calendar-week'}
+            size={14}
+            color={colors.primary[400]}
+            solid
+          />
+        </TouchableOpacity>
+      </View>
+
+      {/* 자녀 필터바 */}
+      <View style={styles.filterBar}>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.filterContent}
+        >
+          <TouchableOpacity
+            style={[styles.filterBtn, selectedChildId === 'all' && styles.filterBtnSelected]}
+            onPress={() => setSelectedChildId('all')}
+            activeOpacity={0.7}
+          >
+            <Text
+              style={[styles.filterText, selectedChildId === 'all' && styles.filterTextSelected]}
+            >
+              전체
+            </Text>
+          </TouchableOpacity>
+          {MOCK_CAL_CHILDREN.map((child) => {
+            const selected = selectedChildId === child.id;
+            return (
+              <TouchableOpacity
+                key={child.id}
+                style={[styles.filterBtn, selected && styles.filterBtnSelected]}
+                onPress={() => setSelectedChildId(child.id)}
+                activeOpacity={0.7}
+              >
+                <View style={[styles.filterDot, { backgroundColor: child.calendarColor }]} />
+                <Text style={[styles.filterText, selected && styles.filterTextSelected]}>
+                  {child.name}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </ScrollView>
+      </View>
+
+      {isWeekMode ? (
+        <>
+          {/* 주간 날짜 바 */}
+          <WeekCalendar
+            weekDates={weekDates}
+            today={today}
+            markedDates={markedDates}
+            onPrev={() => setWeekOffset((o) => o - 1)}
+            onNext={() => setWeekOffset((o) => o + 1)}
+          />
+
+          {/* 주간 일정 목록 */}
+          <ScrollView
+            ref={weekScrollRef}
+            style={styles.list}
+            showsVerticalScrollIndicator={false}
+            onContentSizeChange={() => {
+              if (weekOffsetRef.current !== 0) return;
+              requestAnimationFrame(() => {
+                if (weekOffsetRef.current !== 0 || todayGroupY.current === undefined) return;
+                weekScrollRef.current?.scrollTo({ y: todayGroupY.current, animated: false });
+              });
+            }}
+          >
+            <View style={styles.weekListContent}>
+              {weekEventGroups.length === 0 ? (
+                <Text style={styles.emptyText}>이번 주 일정이 없어요</Text>
+              ) : (
+                weekEventGroups.map((group) => (
+                  <View
+                    key={group.date}
+                    onLayout={(e) => {
+                      if (group.date === today) {
+                        todayGroupY.current = e.nativeEvent.layout.y;
+                      }
+                    }}
+                  >
+                    <Text style={styles.weekDateHeader}>{formatWeekDateHeader(group.date)}</Text>
+                    <View style={styles.cardGroup}>
+                      {group.events.map((event) => (
+                        <EventCard
+                          key={event.id}
+                          event={event}
+                          expanded={expandedIds.has(event.id)}
+                          isPast={event.date < today}
+                          onToggleExpand={() => toggleExpand(event.id)}
+                          onToggleCheck={(checkId) => toggleCheck(event.id, checkId)}
+                        />
+                      ))}
+                    </View>
+                  </View>
+                ))
+              )}
+            </View>
+          </ScrollView>
+        </>
+      ) : (
+        <>
+          {/* 월간 캘린더 */}
+          <MonthCalendar
+            year={calendarMonth.year}
+            month={calendarMonth.month}
+            today={today}
+            selectedDate={selectedDate}
+            markedDates={markedDates}
+            onDayPress={setSelectedDate}
+            onPrevMonth={handlePrevMonth}
+            onNextMonth={handleNextMonth}
+          />
+
+          {/* 선택 날짜 + 일정 목록 */}
+          <ScrollView style={styles.list} showsVerticalScrollIndicator={false}>
+            <Text style={styles.dayLabel}>{formatDayLabel(selectedDate)}</Text>
+            <View style={styles.listContent}>
+              {dayEvents.length === 0 ? (
+                <Text style={styles.emptyText}>일정이 없어요</Text>
+              ) : (
+                dayEvents.map((event) => (
+                  <EventCard
+                    key={event.id}
+                    event={event}
+                    expanded={expandedIds.has(event.id)}
+                    isPast={event.date < today}
+                    onToggleExpand={() => toggleExpand(event.id)}
+                    onToggleCheck={(checkId) => toggleCheck(event.id, checkId)}
+                  />
+                ))
+              )}
+            </View>
+          </ScrollView>
+        </>
+      )}
+    </View>
+  );
+};
 
 export default CalendarScreen;
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: colors.text.white,
-  },
-  text: {
-    fontSize: 18,
-    fontFamily: fonts.semiBold,
-    color: colors.text.primary,
-  },
-});

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -159,6 +159,7 @@ const CalendarScreen = () => {
           style={styles.iconButton}
           onPress={() => router.back()}
           accessibilityRole="button"
+          accessibilityLabel="뒤로가기"
         >
           <Ionicons name="arrow-back" size={16} color={colors.gray[300]} />
         </TouchableOpacity>
@@ -167,6 +168,7 @@ const CalendarScreen = () => {
           style={[styles.iconButton, styles.calendarIconButton]}
           onPress={handleToggleMode}
           accessibilityRole="button"
+          accessibilityLabel={isWeekMode ? '월간 보기로 전환' : '주간 보기로 전환'}
         >
           <FontAwesome5
             name={isWeekMode ? 'calendar-alt' : 'calendar-week'}

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -137,17 +137,27 @@ const CalendarScreen = () => {
     setExpandedIds(new Set());
   };
 
+  const syncSelectedDateToMonth = (year: number, month: number) => {
+    setSelectedDate((prev) => {
+      const day = Number(prev.split('-')[2]);
+      const lastDay = new Date(year, month + 1, 0).getDate();
+      return `${year}-${String(month + 1).padStart(2, '0')}-${String(Math.min(day, lastDay)).padStart(2, '0')}`;
+    });
+  };
+
   const handlePrevMonth = () => {
     setCalendarMonth(({ year, month }) => {
-      if (month === 0) return { year: year - 1, month: 11 };
-      return { year, month: month - 1 };
+      const next = month === 0 ? { year: year - 1, month: 11 } : { year, month: month - 1 };
+      syncSelectedDateToMonth(next.year, next.month);
+      return next;
     });
   };
 
   const handleNextMonth = () => {
     setCalendarMonth(({ year, month }) => {
-      if (month === 11) return { year: year + 1, month: 0 };
-      return { year, month: month + 1 };
+      const next = month === 11 ? { year: year + 1, month: 0 } : { year, month: month + 1 };
+      syncSelectedDateToMonth(next.year, next.month);
+      return next;
     });
   };
 
@@ -292,7 +302,7 @@ const CalendarScreen = () => {
             <Text style={styles.dayLabel}>{formatDayLabel(selectedDate)}</Text>
             <View style={styles.listContent}>
               {dayEvents.length === 0 ? (
-                <Text style={styles.emptyText}>일정이 없어요</Text>
+                <Text style={styles.emptyText}>등록된 일정이 없어요</Text>
               ) : (
                 dayEvents.map((event) => (
                   <EventCard

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef } from 'react';
+import { useState, useMemo, useRef, useEffect } from 'react';
 import { View, Text, ScrollView, TouchableOpacity } from 'react-native';
 import { Ionicons, FontAwesome5 } from '@expo/vector-icons';
 import { router } from 'expo-router';
@@ -48,8 +48,13 @@ const CalendarScreen = () => {
 
   const weekScrollRef = useRef<ScrollView>(null);
   const weekOffsetRef = useRef(weekOffset);
+  const shouldAutoScrollRef = useRef(weekOffset === 0);
   weekOffsetRef.current = weekOffset;
   const todayGroupY = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    shouldAutoScrollRef.current = weekOffset === 0;
+  }, [weekOffset]);
 
   const filteredByChild = useMemo(
     () => events.filter((e) => selectedChildId === 'all' || e.childId === selectedChildId),
@@ -226,10 +231,11 @@ const CalendarScreen = () => {
             style={styles.list}
             showsVerticalScrollIndicator={false}
             onContentSizeChange={() => {
-              if (weekOffsetRef.current !== 0) return;
+              if (weekOffsetRef.current !== 0 || !shouldAutoScrollRef.current) return;
               requestAnimationFrame(() => {
                 if (weekOffsetRef.current !== 0 || todayGroupY.current === undefined) return;
                 weekScrollRef.current?.scrollTo({ y: todayGroupY.current, animated: false });
+                shouldAutoScrollRef.current = false;
               });
             }}
           >

--- a/src/components/calendar/EventCard.tsx
+++ b/src/components/calendar/EventCard.tsx
@@ -1,0 +1,98 @@
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Ionicons, FontAwesome } from '@expo/vector-icons';
+import colors from '../../constants/colors';
+import type { CalendarEvent } from '../../mock/calendar';
+import calStyles from '../../styles/calendar/calendar';
+
+interface EventCardProps {
+  event: CalendarEvent;
+  expanded: boolean;
+  isPast: boolean;
+  onToggleExpand: () => void;
+  onToggleCheck: (checkId: string) => void;
+}
+
+const calcDDay = (dateStr: string): number => {
+  const todayDate = new Date();
+  todayDate.setHours(0, 0, 0, 0);
+  const [year, month, day] = dateStr.split('-').map(Number);
+  const target = new Date(year, month - 1, day);
+  return Math.round((target.getTime() - todayDate.getTime()) / (1000 * 60 * 60 * 24));
+};
+
+const EventCard = ({ event, expanded, isPast, onToggleExpand, onToggleCheck }: EventCardProps) => {
+  const dDay = calcDDay(event.date);
+
+  return (
+    <View style={[calStyles.card, isPast && styles.past]}>
+      <View style={calStyles.cardHeader}>
+        <View style={calStyles.cardLeft}>
+          <Text style={calStyles.cardTitle}>{event.title}</Text>
+          <View style={calStyles.cardTags}>
+            <View style={calStyles.tag}>
+              <Text style={calStyles.tagText}>{event.childName}</Text>
+            </View>
+            <View style={calStyles.tag}>
+              <Text style={calStyles.tagText} numberOfLines={1}>
+                {event.documentTitle}
+              </Text>
+            </View>
+          </View>
+        </View>
+        <View style={calStyles.cardRight}>
+          {!isPast && (
+            <View style={[calStyles.dDayBadge, dDay === 0 && calStyles.dDayBadgeUrgent]}>
+              <Text style={[calStyles.dDayText, dDay === 0 && calStyles.dDayTextUrgent]}>
+                D-{dDay}
+              </Text>
+            </View>
+          )}
+          <TouchableOpacity
+            onPress={onToggleExpand}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Ionicons
+              name={expanded ? 'chevron-up' : 'chevron-down'}
+              size={16}
+              color={colors.gray[300]}
+            />
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      {expanded && (
+        <View style={[calStyles.checklistWrap, { backgroundColor: `${event.calendarColor}26` }]}>
+          {event.checkList.map((item) => (
+            <TouchableOpacity
+              key={item.id}
+              style={calStyles.checkItem}
+              onPress={() => onToggleCheck(item.id)}
+              activeOpacity={0.7}
+            >
+              <View
+                style={[
+                  calStyles.checkbox,
+                  { borderColor: event.calendarColor },
+                  item.done && { backgroundColor: event.calendarColor },
+                ]}
+              >
+                {item.done && <FontAwesome name="check" size={10} color={colors.text.white} />}
+              </View>
+              <Text style={[calStyles.checkText, item.done && calStyles.checkTextDone]}>
+                {item.label}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+};
+
+export default EventCard;
+
+const styles = StyleSheet.create({
+  past: {
+    opacity: 0.6,
+  },
+});

--- a/src/components/calendar/EventCard.tsx
+++ b/src/components/calendar/EventCard.tsx
@@ -50,6 +50,9 @@ const EventCard = ({ event, expanded, isPast, onToggleExpand, onToggleCheck }: E
           <TouchableOpacity
             onPress={onToggleExpand}
             hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            accessibilityRole="button"
+            accessibilityLabel={expanded ? '체크리스트 접기' : '체크리스트 펼치기'}
+            accessibilityState={{ expanded }}
           >
             <Ionicons
               name={expanded ? 'chevron-up' : 'chevron-down'}
@@ -68,6 +71,9 @@ const EventCard = ({ event, expanded, isPast, onToggleExpand, onToggleCheck }: E
               style={calStyles.checkItem}
               onPress={() => onToggleCheck(item.id)}
               activeOpacity={0.7}
+              accessibilityRole="checkbox"
+              accessibilityLabel={item.label}
+              accessibilityState={{ checked: item.done }}
             >
               <View
                 style={[

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -64,13 +64,23 @@ const MonthCalendar = ({
   return (
     <View style={styles.container}>
       <View style={styles.header}>
-        <TouchableOpacity onPress={onPrevMonth} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+        <TouchableOpacity
+          onPress={onPrevMonth}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          accessibilityRole="button"
+          accessibilityLabel="이전 달"
+        >
           <Ionicons name="chevron-back" size={16} color={colors.text.secondary} />
         </TouchableOpacity>
         <Text style={styles.headerText}>
           {year}년 {month + 1}월
         </Text>
-        <TouchableOpacity onPress={onNextMonth} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+        <TouchableOpacity
+          onPress={onNextMonth}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          accessibilityRole="button"
+          accessibilityLabel="다음 달"
+        >
           <Ionicons name="chevron-forward" size={16} color={colors.text.secondary} />
         </TouchableOpacity>
       </View>

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -1,0 +1,201 @@
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import colors from '../../constants/colors';
+import fonts from '../../constants/fonts';
+
+interface MonthCalendarProps {
+  year: number;
+  month: number;
+  today: string;
+  selectedDate: string;
+  markedDates: Record<string, { dots?: { key: string; color: string }[] }>;
+  onDayPress: (dateStr: string) => void;
+  onPrevMonth: () => void;
+  onNextMonth: () => void;
+}
+
+const DAY_NAMES = ['일', '월', '화', '수', '목', '금', '토'];
+
+const toDateStr = (y: number, m: number, d: number) =>
+  `${y}-${String(m + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+
+const MonthCalendar = ({
+  year,
+  month,
+  today,
+  selectedDate,
+  markedDates,
+  onDayPress,
+  onPrevMonth,
+  onNextMonth,
+}: MonthCalendarProps) => {
+  const firstDayOfWeek = new Date(year, month, 1).getDay();
+  const lastDate = new Date(year, month + 1, 0).getDate();
+  const prevLastDate = new Date(year, month, 0).getDate();
+
+  const prevMonth = month === 0 ? 11 : month - 1;
+  const prevYear = month === 0 ? year - 1 : year;
+  const nextMonth = month === 11 ? 0 : month + 1;
+  const nextYear = month === 11 ? year + 1 : year;
+
+  const prevCells = Array.from({ length: firstDayOfWeek }, (_, i) => ({
+    dateStr: toDateStr(prevYear, prevMonth, prevLastDate - (firstDayOfWeek - 1 - i)),
+    inMonth: false,
+  }));
+
+  const currCells = Array.from({ length: lastDate }, (_, i) => ({
+    dateStr: toDateStr(year, month, i + 1),
+    inMonth: true,
+  }));
+
+  const totalRows = Math.ceil((firstDayOfWeek + lastDate) / 7);
+  const totalCells = totalRows * 7;
+  const nextCount = totalCells - firstDayOfWeek - lastDate;
+
+  const nextCells = Array.from({ length: nextCount }, (_, i) => ({
+    dateStr: toDateStr(nextYear, nextMonth, i + 1),
+    inMonth: false,
+  }));
+
+  const cells = [...prevCells, ...currCells, ...nextCells];
+
+  const weeks = Array.from({ length: totalRows }, (_, i) => cells.slice(i * 7, i * 7 + 7));
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={onPrevMonth} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+          <Ionicons name="chevron-back" size={16} color={colors.text.secondary} />
+        </TouchableOpacity>
+        <Text style={styles.headerText}>
+          {year}년 {month + 1}월
+        </Text>
+        <TouchableOpacity onPress={onNextMonth} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+          <Ionicons name="chevron-forward" size={16} color={colors.text.secondary} />
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.weekRow}>
+        {DAY_NAMES.map((name) => (
+          <View key={name} style={styles.dayCell}>
+            <Text style={styles.dayName}>{name}</Text>
+          </View>
+        ))}
+      </View>
+
+      {weeks.map((week) => (
+        <View key={week[0].dateStr} style={styles.weekRow}>
+          {week.map(({ dateStr, inMonth }) => {
+            const day = parseInt(dateStr.split('-')[2], 10);
+            const isToday = dateStr === today;
+            const isSelected = dateStr === selectedDate && !isToday;
+            const dots = markedDates[dateStr]?.dots ?? [];
+            return (
+              <TouchableOpacity
+                key={dateStr}
+                style={styles.dayCell}
+                onPress={() => inMonth && onDayPress(dateStr)}
+                activeOpacity={inMonth ? 0.7 : 1}
+              >
+                <View
+                  style={[
+                    styles.dateCircle,
+                    isToday && styles.todayCircle,
+                    isSelected && styles.selectedCircle,
+                  ]}
+                >
+                  <Text
+                    style={[
+                      styles.dateText,
+                      !inMonth && styles.outsideText,
+                      isToday && styles.todayText,
+                    ]}
+                  >
+                    {day}
+                  </Text>
+                </View>
+                <View style={styles.dotsRow}>
+                  {dots.slice(0, 3).map((dot) => (
+                    <View key={dot.key} style={[styles.dot, { backgroundColor: dot.color }]} />
+                  ))}
+                </View>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      ))}
+    </View>
+  );
+};
+
+export default MonthCalendar;
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.text.white,
+    paddingHorizontal: 20,
+    paddingTop: 12,
+    paddingBottom: 12,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+    marginHorizontal: 16,
+  },
+  headerText: {
+    fontSize: 14,
+    fontFamily: fonts.medium,
+    color: '#1A1A1A',
+  },
+  weekRow: {
+    flexDirection: 'row',
+  },
+  dayCell: {
+    flex: 1,
+    alignItems: 'center',
+    gap: 4,
+    paddingVertical: 2,
+  },
+  dayName: {
+    fontSize: 13,
+    fontFamily: fonts.medium,
+    color: '#888888',
+  },
+  dateCircle: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  todayCircle: {
+    backgroundColor: colors.primary[500],
+  },
+  selectedCircle: {
+    backgroundColor: colors.gray[200],
+    borderRadius: 16,
+  },
+  dateText: {
+    fontSize: 14,
+    fontFamily: fonts.medium,
+    color: colors.text.primary,
+  },
+  todayText: {
+    color: colors.text.white,
+  },
+  outsideText: {
+    color: colors.gray[200],
+  },
+  dotsRow: {
+    flexDirection: 'row',
+    gap: 2,
+    height: 4,
+  },
+  dot: {
+    width: 4,
+    height: 4,
+    borderRadius: 2,
+  },
+});

--- a/src/components/calendar/WeekCalendar.tsx
+++ b/src/components/calendar/WeekCalendar.tsx
@@ -22,13 +22,23 @@ const WeekCalendar = ({ weekDates, today, markedDates, onPrev, onNext }: WeekCal
   <View style={styles.container}>
     {/* 날짜 범위 헤더 */}
     <View style={styles.rangeHeader}>
-      <TouchableOpacity onPress={onPrev} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+      <TouchableOpacity
+        onPress={onPrev}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        accessibilityRole="button"
+        accessibilityLabel="이전 주"
+      >
         <Ionicons name="chevron-back" size={16} color={colors.text.secondary} />
       </TouchableOpacity>
       <Text style={styles.rangeText}>
         {formatMonthDay(weekDates[0])} ~ {formatMonthDay(weekDates[6])}
       </Text>
-      <TouchableOpacity onPress={onNext} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+      <TouchableOpacity
+        onPress={onNext}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        accessibilityRole="button"
+        accessibilityLabel="다음 주"
+      >
         <Ionicons name="chevron-forward" size={16} color={colors.text.secondary} />
       </TouchableOpacity>
     </View>

--- a/src/components/calendar/WeekCalendar.tsx
+++ b/src/components/calendar/WeekCalendar.tsx
@@ -1,0 +1,123 @@
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import colors from '../../constants/colors';
+import fonts from '../../constants/fonts';
+
+interface WeekCalendarProps {
+  weekDates: string[];
+  today: string;
+  markedDates: Record<string, { dots?: { key: string; color: string }[] }>;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+const DAY_NAMES = ['일', '월', '화', '수', '목', '금', '토'];
+
+const formatMonthDay = (dateStr: string) => {
+  const [, month, day] = dateStr.split('-').map(Number);
+  return `${month}월 ${day}일`;
+};
+
+const WeekCalendar = ({ weekDates, today, markedDates, onPrev, onNext }: WeekCalendarProps) => (
+  <View style={styles.container}>
+    {/* 날짜 범위 헤더 */}
+    <View style={styles.rangeHeader}>
+      <TouchableOpacity onPress={onPrev} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+        <Ionicons name="chevron-back" size={16} color={colors.text.secondary} />
+      </TouchableOpacity>
+      <Text style={styles.rangeText}>
+        {formatMonthDay(weekDates[0])} ~ {formatMonthDay(weekDates[6])}
+      </Text>
+      <TouchableOpacity onPress={onNext} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+        <Ionicons name="chevron-forward" size={16} color={colors.text.secondary} />
+      </TouchableOpacity>
+    </View>
+
+    {/* 요일 + 날짜 + dot */}
+    <View style={styles.datesRow}>
+      {weekDates.map((dateStr, index) => {
+        const day = parseInt(dateStr.split('-')[2], 10);
+        const isToday = dateStr === today;
+        const dots = markedDates[dateStr]?.dots ?? [];
+
+        return (
+          <View key={dateStr} style={styles.dayCell}>
+            <Text style={styles.dayName}>{DAY_NAMES[index]}</Text>
+            <View style={[styles.dateCircle, isToday && styles.todayCircle]}>
+              <Text style={[styles.dateText, isToday && styles.todayText]}>{day}</Text>
+            </View>
+            <View style={styles.dotsRow}>
+              {dots.slice(0, 3).map((dot) => (
+                <View key={dot.key} style={[styles.dot, { backgroundColor: dot.color }]} />
+              ))}
+            </View>
+          </View>
+        );
+      })}
+    </View>
+  </View>
+);
+
+export default WeekCalendar;
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.text.white,
+    paddingHorizontal: 20,
+    paddingTop: 12,
+    paddingBottom: 12,
+  },
+  rangeHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 14,
+    marginHorizontal: 16,
+  },
+  rangeText: {
+    fontSize: 14,
+    fontFamily: fonts.medium,
+    color: '#1A1A1A',
+  },
+  datesRow: {
+    flexDirection: 'row',
+  },
+  dayCell: {
+    flex: 1,
+    alignItems: 'center',
+    gap: 4,
+  },
+  dayName: {
+    fontSize: 13,
+    fontFamily: fonts.medium,
+    color: '#888888',
+  },
+  dateCircle: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  todayCircle: {
+    backgroundColor: colors.primary[500],
+  },
+  dateText: {
+    fontSize: 14,
+    fontFamily: fonts.medium,
+    color: colors.text.primary,
+  },
+  todayText: {
+    color: colors.text.white,
+  },
+  dotsRow: {
+    flexDirection: 'row',
+    gap: 2,
+    height: 4,
+  },
+  dot: {
+    width: 4,
+    height: 4,
+    borderRadius: 2,
+  },
+});

--- a/src/mock/calendar.ts
+++ b/src/mock/calendar.ts
@@ -1,0 +1,128 @@
+export interface CalendarChild {
+  id: string;
+  name: string;
+  calendarColor: string;
+}
+
+export interface CalendarEvent {
+  id: string;
+  date: string;
+  title: string;
+  childId: string;
+  childName: string;
+  calendarColor: string;
+  documentTitle: string;
+  checkList: { id: string; label: string; done: boolean }[];
+}
+
+export const MOCK_CAL_CHILDREN: CalendarChild[] = [
+  { id: 'child-1', name: '김첫째', calendarColor: '#2CDA00' },
+  { id: 'child-2', name: '김둘째', calendarColor: '#FFCC2F' },
+];
+
+export const MOCK_EVENTS: CalendarEvent[] = [
+  {
+    id: '1',
+    date: '2026-05-05',
+    title: '학부모 상담',
+    childId: 'child-1',
+    childName: '김첫째',
+    calendarColor: '#2CDA00',
+    documentTitle: '학부모 상담 안내문',
+    checkList: [
+      { id: '1-1', label: '상담 신청서 제출', done: true },
+      { id: '1-2', label: '상담 시간 확인', done: false },
+    ],
+  },
+  {
+    id: '2',
+    date: '2026-05-05',
+    title: '현장학습 준비물 제출',
+    childId: 'child-2',
+    childName: '김둘째',
+    calendarColor: '#FFCC2F',
+    documentTitle: '2026년 1학기 현장학습 안내',
+    checkList: [
+      { id: '2-1', label: '현장학습 신청서 작성', done: false },
+      { id: '2-2', label: '준비물 챙기기', done: false },
+    ],
+  },
+  {
+    id: '3',
+    date: '2026-05-06',
+    title: '학급 사진 촬영',
+    childId: 'child-1',
+    childName: '김첫째',
+    calendarColor: '#2CDA00',
+    documentTitle: '학급 사진 촬영 안내',
+    checkList: [
+      { id: '3-1', label: '단체 복장 준비', done: false },
+      { id: '3-2', label: '사진 비용 납부', done: true },
+    ],
+  },
+  {
+    id: '4',
+    date: '2026-05-08',
+    title: '어린이날 행사 참가 신청',
+    childId: 'child-2',
+    childName: '김둘째',
+    calendarColor: '#FFCC2F',
+    documentTitle: '어린이날 기념 행사 안내',
+    checkList: [
+      { id: '4-1', label: '참가 신청서 제출', done: false },
+      { id: '4-2', label: '간식비 납부', done: false },
+    ],
+  },
+  {
+    id: '5',
+    date: '2026-05-10',
+    title: '급식 신청 마감',
+    childId: 'child-1',
+    childName: '김첫째',
+    calendarColor: '#2CDA00',
+    documentTitle: '5월 급식 식단표 및 영양 정보',
+    checkList: [
+      { id: '5-1', label: '급식비 납부', done: true },
+      { id: '5-2', label: '알레르기 정보 제출', done: false },
+    ],
+  },
+  {
+    id: '6',
+    date: '2026-05-10',
+    title: '스포츠 클럽 신청 마감',
+    childId: 'child-2',
+    childName: '김둘째',
+    calendarColor: '#FFCC2F',
+    documentTitle: '스포츠 클럽 참가 신청 안내',
+    checkList: [
+      { id: '6-1', label: '신청서 작성', done: false },
+      { id: '6-2', label: '참가비 납부', done: false },
+    ],
+  },
+  {
+    id: '7',
+    date: '2026-05-04',
+    title: '봄 소풍 신청',
+    childId: 'child-1',
+    childName: '김첫째',
+    calendarColor: '#2CDA00',
+    documentTitle: '봄 소풍 안내문',
+    checkList: [
+      { id: '7-1', label: '참가 동의서 제출', done: true },
+      { id: '7-2', label: '도시락 준비', done: true },
+    ],
+  },
+  {
+    id: '8',
+    date: '2026-04-30',
+    title: '4월 생활기록부 확인',
+    childId: 'child-2',
+    childName: '김둘째',
+    calendarColor: '#FFCC2F',
+    documentTitle: '생활기록부 열람 안내',
+    checkList: [
+      { id: '8-1', label: '온라인 열람 신청', done: true },
+      { id: '8-2', label: '내용 확인 후 서명', done: false },
+    ],
+  },
+];

--- a/src/styles/calendar/calendar.ts
+++ b/src/styles/calendar/calendar.ts
@@ -1,0 +1,210 @@
+import { StyleSheet } from 'react-native';
+import colors from '../../constants/colors';
+import fonts from '../../constants/fonts';
+import layout from '../../constants/layout';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.gray[100],
+  },
+
+  // 헤더
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingTop: 60,
+    paddingBottom: 12,
+    paddingHorizontal: layout.screenPaddingHorizontal,
+    backgroundColor: colors.text.white,
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontFamily: fonts.semiBold,
+    color: colors.text.primary,
+  },
+  iconButton: {
+    width: 30,
+    height: 30,
+    borderRadius: 15,
+    borderWidth: 1,
+    borderColor: colors.gray[300],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  calendarIconButton: {
+    borderColor: colors.primary[400],
+  },
+
+  // 자녀 필터바
+  filterBar: {
+    height: 53,
+    backgroundColor: colors.text.white,
+    justifyContent: 'center',
+  },
+  filterContent: {
+    alignItems: 'center',
+    paddingHorizontal: layout.screenPaddingHorizontal,
+    gap: 10,
+  },
+  filterBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    height: 31,
+    borderRadius: 15,
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+    paddingHorizontal: 14,
+    backgroundColor: colors.text.white,
+    gap: 6,
+  },
+  filterBtnSelected: {
+    backgroundColor: colors.primary[500],
+    borderWidth: 0,
+  },
+  filterText: {
+    fontSize: 14,
+    fontFamily: fonts.semiBold,
+    color: colors.text.secondary,
+  },
+  filterTextSelected: {
+    color: colors.text.white,
+  },
+  filterDot: {
+    width: 5,
+    height: 5,
+    borderRadius: 99,
+  },
+
+  // 일정 목록
+  list: {
+    flex: 1,
+  },
+  dayLabel: {
+    fontSize: 14,
+    fontFamily: fonts.medium,
+    color: '#888888',
+    paddingHorizontal: layout.screenPaddingHorizontal,
+    paddingTop: 12,
+    paddingBottom: 8,
+  },
+  listContent: {
+    paddingHorizontal: layout.screenPaddingHorizontal,
+    gap: 10,
+    paddingBottom: layout.screenPaddingBottom,
+  },
+  weekListContent: {
+    gap: 10,
+    paddingBottom: layout.screenPaddingBottom,
+  },
+  emptyText: {
+    fontSize: 14,
+    fontFamily: fonts.medium,
+    color: colors.gray[300],
+    textAlign: 'center',
+    marginTop: 40,
+  },
+  weekDateHeader: {
+    fontSize: 14,
+    fontFamily: fonts.medium,
+    color: '#888888',
+    paddingHorizontal: layout.screenPaddingHorizontal,
+    paddingTop: 12,
+    paddingBottom: 8,
+  },
+  cardGroup: {
+    paddingHorizontal: layout.screenPaddingHorizontal,
+    gap: 10,
+  },
+
+  // 일정 카드
+  card: {
+    backgroundColor: colors.text.white,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: colors.gray[100],
+    overflow: 'hidden',
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    padding: 15,
+  },
+  cardLeft: {
+    flex: 1,
+    gap: 6,
+  },
+  cardRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  cardTitle: {
+    fontSize: 14,
+    fontFamily: fonts.medium,
+    color: '#000000',
+  },
+  cardTags: {
+    flexDirection: 'row',
+    gap: 10,
+  },
+  tag: {
+    backgroundColor: colors.gray[100],
+    borderRadius: 8,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+  },
+  tagText: {
+    fontSize: 12,
+    fontFamily: fonts.medium,
+    color: colors.gray[300],
+  },
+  dDayBadge: {
+    backgroundColor: colors.gray[100],
+    borderRadius: 10,
+    paddingHorizontal: 6,
+    paddingVertical: 3,
+  },
+  dDayBadgeUrgent: {
+    backgroundColor: 'rgba(229, 57, 53, 0.2)',
+  },
+  dDayText: {
+    fontSize: 12,
+    fontFamily: fonts.semiBold,
+    color: colors.text.secondary,
+  },
+  dDayTextUrgent: {
+    color: colors.text.red,
+  },
+
+  // 체크리스트
+  checklistWrap: {
+    padding: 15,
+    gap: 10,
+  },
+  checkItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  checkbox: {
+    width: 16,
+    height: 16,
+    borderRadius: 2,
+    borderWidth: 1.5,
+    backgroundColor: colors.text.white,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  checkText: {
+    fontSize: 13,
+    fontFamily: fonts.medium,
+    color: '#000000',
+  },
+  checkTextDone: {
+    textDecorationLine: 'line-through',
+    color: colors.text.secondary,
+  },
+});


### PR DESCRIPTION
## 📌 작업 내용

- 월간 캘린더 구현
  - 월 네비게이션, 날짜 그리드(이전·다음달 포함), 오늘/선택 날짜 원형 표시, 이벤트 dot
- 주간 캘린더 구현
  - 주 네비게이션, 요일·날짜·이벤트 dot 표시
  - 이번 주 진입 시 오늘 날짜 그룹으로 자동 스크롤
- 일정 카드 구현
  - D-day 배지 (지난 일정 미표시)
  - 체크리스트 펼치기/접기 및 항목 체크 토글
  - 지난 일정 반투명 처리
- 자녀 필터바 (전체 / 자녀별, 캘린더 색상 dot)
- 기본 진입 화면 주간 모드로 설정

## 📷 스크린 샷
<img width="300" src="https://github.com/user-attachments/assets/307ca569-c7aa-4d22-b7d7-fff68d94a7d3" />
<img width="300" src="https://github.com/user-attachments/assets/0817d018-6386-4cce-a272-85e84207635b" />


## ⚠️ 참고 사항

-

## 🔗 관련 이슈

Closes #33 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 완전한 캘린더 UI 구현 (주간/월간 보기 전환 가능)
  * 이벤트 카드 확장/축소 및 체크리스트 기능
  * 자녀별 필터링 및 날짜별 색상 마커 표시
  * 당일 자동 스크롤 및 월 내비게이션

<!-- end of auto-generated comment: release notes by coderabbit.ai -->