### PR TITLE
✨ [Feature] 가정통신문 API 연동 (#37)

### DIFF
--- a/app/scan/camera.tsx
+++ b/app/scan/camera.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { View, Text, Alert, TouchableOpacity, StyleSheet } from 'react-native';
 import { CameraView, useCameraPermissions } from 'expo-camera';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -14,9 +14,8 @@ import ScanCornerBrackets from '../../src/components/scan/ScanCornerBrackets';
 import colors from '../../src/constants/colors';
 import fonts from '../../src/constants/fonts';
 import { SCAN_FRAME_W, SCAN_FRAME_H, SCAN_DEFAULT_CHILD_COLOR } from '../../src/constants/scan';
-import React from 'react';
 
-export default function ScanCameraScreen() {
+const ScanCameraScreen = () => {
   const { childId, childName, childColor, childGrade } = useLocalSearchParams<{
     childId: string;
     childName: string;
@@ -31,11 +30,10 @@ export default function ScanCameraScreen() {
   const insets = useSafeAreaInsets();
 
   const compressImage = async (uri: string): Promise<string> => {
-    const result = await manipulateAsync(
-      uri,
-      [{ resize: { width: 2048 } }],
-      { compress: 0.85, format: SaveFormat.JPEG }
-    );
+    const result = await manipulateAsync(uri, [{ resize: { width: 2048 } }], {
+      compress: 0.85,
+      format: SaveFormat.JPEG,
+    });
     return result.uri;
   };
 
@@ -173,7 +171,9 @@ export default function ScanCameraScreen() {
       <ScanHelpModal visible={helpVisible} onClose={() => setHelpVisible(false)} />
     </View>
   );
-}
+};
+
+export default ScanCameraScreen;
 
 const styles = StyleSheet.create({
   screen: {

--- a/app/scan/camera.tsx
+++ b/app/scan/camera.tsx
@@ -5,6 +5,7 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as ImagePicker from 'expo-image-picker';
+import { manipulateAsync, SaveFormat } from 'expo-image-manipulator';
 import Header from '../../src/components/common/Header';
 import ScanStepIndicator from '../../src/components/scan/ScanStepIndicator';
 import ScanHelpModal from '../../src/components/scan/ScanHelpModal';
@@ -13,9 +14,11 @@ import ScanCornerBrackets from '../../src/components/scan/ScanCornerBrackets';
 import colors from '../../src/constants/colors';
 import fonts from '../../src/constants/fonts';
 import { SCAN_FRAME_W, SCAN_FRAME_H, SCAN_DEFAULT_CHILD_COLOR } from '../../src/constants/scan';
+import React from 'react';
 
 export default function ScanCameraScreen() {
-  const { childName, childColor, childGrade } = useLocalSearchParams<{
+  const { childId, childName, childColor, childGrade } = useLocalSearchParams<{
+    childId: string;
     childName: string;
     childColor: string;
     childGrade: string;
@@ -27,17 +30,28 @@ export default function ScanCameraScreen() {
   const cameraRef = useRef<CameraView>(null);
   const insets = useSafeAreaInsets();
 
+  const compressImage = async (uri: string): Promise<string> => {
+    const result = await manipulateAsync(
+      uri,
+      [{ resize: { width: 2048 } }],
+      { compress: 0.85, format: SaveFormat.JPEG }
+    );
+    return result.uri;
+  };
+
   const handleCapture = async () => {
     if (!cameraRef.current || capturing) return;
     setCapturing(true);
     try {
       const photo = await cameraRef.current.takePictureAsync({ quality: 1 });
       if (photo) {
+        const compressedUri = await compressImage(photo.uri);
         setCapturing(false);
         router.push({
           pathname: '/scan/preview',
           params: {
-            photoUri: photo.uri,
+            photoUri: compressedUri,
+            childId: childId ?? '',
             childName: childName ?? '',
             childColor: childColor ?? '',
             childGrade: childGrade ?? '',
@@ -69,6 +83,7 @@ export default function ScanCameraScreen() {
           pathname: '/scan/preview',
           params: {
             photoUri: result.assets[0].uri,
+            childId: childId ?? '',
             childName: childName ?? '',
             childColor: childColor ?? '',
             childGrade: childGrade ?? '',

--- a/app/scan/index.tsx
+++ b/app/scan/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   View,
   Text,
@@ -22,7 +22,6 @@ import { getMyChildren, ChildResult } from '../../src/api/child';
 import colors from '../../src/constants/colors';
 import fonts from '../../src/constants/fonts';
 import layout from '../../src/constants/layout';
-import React from 'react';
 
 const ScanChildSelectScreen = () => {
   const [children, setChildren] = useState<ChildResult[]>([]);

--- a/app/scan/index.tsx
+++ b/app/scan/index.tsx
@@ -60,7 +60,12 @@ const ScanChildSelectScreen = () => {
       if (!result.canceled) {
         router.push({
           pathname: '/scan/preview',
-          params: { photoUri: result.assets[0].uri, ...childParams, source: 'gallery' },
+          params: {
+            photoUri: result.assets[0].uri,
+            ...childParams,
+            source: 'pdf',
+            fileType: result.assets[0].mimeType ?? 'application/pdf',
+          },
         });
       }
     } catch {

--- a/app/scan/index.tsx
+++ b/app/scan/index.tsx
@@ -1,35 +1,72 @@
-import { useState } from 'react';
-import { View, Text, Alert, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
+import { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  Alert,
+  TouchableOpacity,
+  ScrollView,
+  StyleSheet,
+  ActivityIndicator,
+} from 'react-native';
 import { router } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
+import * as DocumentPicker from 'expo-document-picker';
+import { manipulateAsync, SaveFormat } from 'expo-image-manipulator';
 import { PrimaryButton } from '../../src/components/common/Button';
 import Header from '../../src/components/common/Header';
 import SelectionCard from '../../src/components/common/SelectionCard';
 import ScanHelpModal from '../../src/components/scan/ScanHelpModal';
 import ScanStepIndicator from '../../src/components/scan/ScanStepIndicator';
+import { getMyChildren, ChildResult } from '../../src/api/child';
 import colors from '../../src/constants/colors';
 import fonts from '../../src/constants/fonts';
 import layout from '../../src/constants/layout';
-
-const CHILDREN = [
-  { id: '1', name: '김첫째', grade: '초등학교 4학년', color: '#2CDA00' },
-  { id: '2', name: '김둘째', grade: '초등학교 1학년', color: '#FFCC2F' },
-];
+import React from 'react';
 
 const ScanChildSelectScreen = () => {
-  const [selectedId, setSelectedId] = useState<string | null>(CHILDREN[0].id);
+  const [children, setChildren] = useState<ChildResult[]>([]);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
   const [helpVisible, setHelpVisible] = useState(false);
+  const [loading, setLoading] = useState(true);
 
-  const selected = CHILDREN.find((c) => c.id === selectedId);
+  useEffect(() => {
+    getMyChildren()
+      .then((result) => {
+        setChildren(result);
+        if (result.length > 0) setSelectedId(result[0].id);
+      })
+      .catch(() => Alert.alert('오류', '자녀 정보를 불러올 수 없어요.'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const selected = children.find((c) => c.id === selectedId);
   const childParams = {
+    childId: String(selectedId ?? ''),
     childName: selected?.name ?? '',
-    childColor: selected?.color ?? '',
-    childGrade: selected?.grade.split(' ').pop() ?? '',
+    childColor: selected?.colorCode ?? '',
+    childGrade: selected ? `초등학교 ${selected.grade}학년` : '',
   };
 
   const handleCamera = () => {
     router.push({ pathname: '/scan/camera', params: childParams });
+  };
+
+  const handlePdf = async () => {
+    try {
+      const result = await DocumentPicker.getDocumentAsync({
+        type: 'application/pdf',
+        copyToCacheDirectory: true,
+      });
+      if (!result.canceled) {
+        router.push({
+          pathname: '/scan/preview',
+          params: { photoUri: result.assets[0].uri, ...childParams, source: 'gallery' },
+        });
+      }
+    } catch {
+      Alert.alert('오류', 'PDF를 불러올 수 없어요.');
+    }
   };
 
   const handleGallery = async () => {
@@ -44,9 +81,14 @@ const ScanChildSelectScreen = () => {
         quality: 1,
       });
       if (!result.canceled) {
+        const compressed = await manipulateAsync(
+          result.assets[0].uri,
+          [{ resize: { width: 2048 } }],
+          { compress: 0.85, format: SaveFormat.JPEG }
+        );
         router.push({
           pathname: '/scan/preview',
-          params: { photoUri: result.assets[0].uri, ...childParams, source: 'gallery' },
+          params: { photoUri: compressed.uri, ...childParams, source: 'gallery' },
         });
       }
     } catch {
@@ -70,18 +112,22 @@ const ScanChildSelectScreen = () => {
         </View>
 
         <View style={styles.childList}>
-          {CHILDREN.map((child) => (
-            <SelectionCard
-              key={child.id}
-              name={child.name}
-              label={child.grade}
-              leftElement={<View style={[styles.avatar, { backgroundColor: child.color }]} />}
-              selected={selectedId === child.id}
-              onPress={() => setSelectedId(child.id)}
-              size="md"
-              indicatorColor={child.color}
-            />
-          ))}
+          {loading ? (
+            <ActivityIndicator color={colors.primary[400]} />
+          ) : (
+            children.map((child) => (
+              <SelectionCard
+                key={child.id}
+                name={child.name}
+                label={`초등학교 ${child.grade}학년`}
+                leftElement={<View style={[styles.avatar, { backgroundColor: child.colorCode }]} />}
+                selected={selectedId === child.id}
+                onPress={() => setSelectedId(child.id)}
+                size="md"
+                indicatorColor={child.colorCode}
+              />
+            ))
+          )}
 
           <TouchableOpacity
             style={[styles.unknownCard, selectedId === null && styles.unknownCardSelected]}
@@ -107,6 +153,7 @@ const ScanChildSelectScreen = () => {
         <View style={styles.buttonGroup}>
           <PrimaryButton label="카메라로 촬영하기" onPress={handleCamera} />
           <PrimaryButton label="갤러리에서 선택하기" onPress={handleGallery} />
+          <PrimaryButton label="PDF 문서로 업로드하기" onPress={handlePdf} />
         </View>
       </ScrollView>
 

--- a/app/scan/loading.tsx
+++ b/app/scan/loading.tsx
@@ -51,7 +51,7 @@ const ScanLoadingScreen = () => {
   const [isComplete, setIsComplete] = useState(false);
   const [helpVisible, setHelpVisible] = useState(false);
   const [newsletterId, setNewsletterId] = useState<number | null>(null);
-  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollingRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const loopScanLine = () => {
@@ -76,7 +76,8 @@ const ScanLoadingScreen = () => {
     let cancelled = false;
 
     const startPolling = (id: number) => {
-      pollingRef.current = setInterval(async () => {
+      const poll = async () => {
+        if (cancelled) return;
         try {
           const result = await getNewsletterStatus(id);
           if (cancelled) return;
@@ -90,18 +91,21 @@ const ScanLoadingScreen = () => {
           }).start();
 
           if (result.status === 'COMPLETED') {
-            if (pollingRef.current) clearInterval(pollingRef.current);
             setIsComplete(true);
+            return;
           } else if (result.status === 'FAILED') {
-            if (pollingRef.current) clearInterval(pollingRef.current);
             Alert.alert('분석 실패', '문서 분석에 실패했어요. 다시 시도해주세요.', [
               { text: '확인', onPress: () => router.back() },
             ]);
+            return;
           }
         } catch {
           // 폴링 중 네트워크 오류는 무시하고 계속 시도
         }
-      }, 2000);
+        pollingRef.current = setTimeout(poll, 2000);
+      };
+
+      pollingRef.current = setTimeout(poll, 2000);
     };
 
     const parsedChildId = childId ? Number(childId) : undefined;
@@ -124,7 +128,7 @@ const ScanLoadingScreen = () => {
 
     return () => {
       cancelled = true;
-      if (pollingRef.current) clearInterval(pollingRef.current);
+      if (pollingRef.current) clearTimeout(pollingRef.current);
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/app/scan/loading.tsx
+++ b/app/scan/loading.tsx
@@ -23,7 +23,7 @@ import { SCAN_FRAME_H } from '../../src/constants/scan';
 import colors from '../../src/constants/colors';
 import styles from '../../src/styles/scan/loading';
 
-export default function ScanLoadingScreen() {
+const ScanLoadingScreen = () => {
   const { photoUri, childId, childName, childColor, childGrade } = useLocalSearchParams<{
     photoUri: string;
     childId: string;
@@ -72,7 +72,7 @@ export default function ScanLoadingScreen() {
   }, [scanLine]);
 
   useEffect(() => {
-    if (!photoUri) return;
+    if (!photoUri) return () => {};
     let cancelled = false;
 
     const startPolling = (id: number) => {
@@ -129,7 +129,7 @@ export default function ScanLoadingScreen() {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    if (!isComplete) return;
+    if (!isComplete) return () => {};
 
     completionAnimation.current = Animated.parallel([
       Animated.timing(frameOpacity, {
@@ -300,4 +300,6 @@ export default function ScanLoadingScreen() {
       <ScanHelpModal visible={helpVisible} onClose={() => setHelpVisible(false)} />
     </View>
   );
-}
+};
+
+export default ScanLoadingScreen;

--- a/app/scan/loading.tsx
+++ b/app/scan/loading.tsx
@@ -1,20 +1,32 @@
-import { useEffect, useRef, useState } from 'react';
-import { View, Image, Text, Animated, ActivityIndicator, TouchableOpacity } from 'react-native';
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  View,
+  Image,
+  Text,
+  Animated,
+  ActivityIndicator,
+  TouchableOpacity,
+  Alert,
+} from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Header from '../../src/components/common/Header';
 import ScanHelpModal from '../../src/components/scan/ScanHelpModal';
 import ScanStepIndicator from '../../src/components/scan/ScanStepIndicator';
+import {
+  uploadNewsletter,
+  getNewsletterStatus,
+  NewsletterApiError,
+} from '../../src/api/newsletter';
 import { SCAN_FRAME_H } from '../../src/constants/scan';
 import colors from '../../src/constants/colors';
 import styles from '../../src/styles/scan/loading';
 
-const SCAN_DURATION = 20000;
-
 export default function ScanLoadingScreen() {
-  const { photoUri, childName, childColor, childGrade } = useLocalSearchParams<{
+  const { photoUri, childId, childName, childColor, childGrade } = useLocalSearchParams<{
     photoUri: string;
+    childId: string;
     childName: string;
     childColor: string;
     childGrade: string;
@@ -35,22 +47,13 @@ export default function ScanLoadingScreen() {
   const glowAnimation = useRef<Animated.CompositeAnimation | null>(null);
   const completionAnimation = useRef<Animated.CompositeAnimation | null>(null);
   const [displayPercent, setDisplayPercent] = useState(0);
+  const [progressMessage, setProgressMessage] = useState('문서를 준비하고 있어요');
   const [isComplete, setIsComplete] = useState(false);
   const [helpVisible, setHelpVisible] = useState(false);
+  const [newsletterId, setNewsletterId] = useState<number | null>(null);
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
-    const listenerId = progress.addListener(({ value }) => {
-      setDisplayPercent(Math.round(value * 100));
-    });
-
-    Animated.timing(progress, {
-      toValue: 1,
-      duration: SCAN_DURATION,
-      useNativeDriver: false,
-    }).start(({ finished }) => {
-      if (finished) setIsComplete(true);
-    });
-
     const loopScanLine = () => {
       scanLine.setValue(0);
       Animated.timing(scanLine, {
@@ -64,11 +67,66 @@ export default function ScanLoadingScreen() {
     loopScanLine();
 
     return () => {
-      progress.removeListener(listenerId);
-      progress.stopAnimation();
       scanLine.stopAnimation();
     };
-  }, [progress, scanLine]);
+  }, [scanLine]);
+
+  useEffect(() => {
+    if (!photoUri) return;
+    let cancelled = false;
+
+    const startPolling = (id: number) => {
+      pollingRef.current = setInterval(async () => {
+        try {
+          const result = await getNewsletterStatus(id);
+          if (cancelled) return;
+
+          setDisplayPercent(result.progressPercent);
+          setProgressMessage(result.progressMessage);
+          Animated.timing(progress, {
+            toValue: result.progressPercent / 100,
+            duration: 400,
+            useNativeDriver: false,
+          }).start();
+
+          if (result.status === 'COMPLETED') {
+            if (pollingRef.current) clearInterval(pollingRef.current);
+            setIsComplete(true);
+          } else if (result.status === 'FAILED') {
+            if (pollingRef.current) clearInterval(pollingRef.current);
+            Alert.alert('분석 실패', '문서 분석에 실패했어요. 다시 시도해주세요.', [
+              { text: '확인', onPress: () => router.back() },
+            ]);
+          }
+        } catch {
+          // 폴링 중 네트워크 오류는 무시하고 계속 시도
+        }
+      }, 2000);
+    };
+
+    const parsedChildId = childId ? Number(childId) : undefined;
+    uploadNewsletter(photoUri, parsedChildId)
+      .then((result) => {
+        if (cancelled) return;
+        setNewsletterId(result.newsletterId);
+        startPolling(result.newsletterId);
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        let message = '업로드에 실패했어요. 다시 시도해주세요.';
+        if (error instanceof NewsletterApiError) {
+          if (error.code === 'NL4091') message = '이미 업로드된 가정통신문이에요.';
+          else if (error.code === 'NL4002') message = '지원하지 않는 파일 형식이에요.';
+          else if (error.code === 'NL4003') message = '파일 크기가 10MB를 초과해요.';
+        }
+        Alert.alert('업로드 실패', message, [{ text: '확인', onPress: () => router.back() }]);
+      });
+
+    return () => {
+      cancelled = true;
+      if (pollingRef.current) clearInterval(pollingRef.current);
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (!isComplete) return;
@@ -192,7 +250,7 @@ export default function ScanLoadingScreen() {
           )}
           <View style={styles.statusTexts}>
             <Text style={styles.statusTitle}>
-              {isComplete ? '번역 및 요약을 완료했어요!' : '문서를 스캔 중이에요 ...'}
+              {isComplete ? '번역 및 요약을 완료했어요!' : progressMessage}
             </Text>
             {!isComplete && (
               <Text style={styles.statusSubtitle}>텍스트와 레이아웃을 분석하고 있어요</Text>
@@ -225,7 +283,13 @@ export default function ScanLoadingScreen() {
             onPress={() =>
               router.push({
                 pathname: '/scan/result',
-                params: { photoUri, childName, childColor, childGrade },
+                params: {
+                  photoUri,
+                  childName,
+                  childColor,
+                  childGrade,
+                  newsletterId: String(newsletterId),
+                },
               })
             }
           >

--- a/app/scan/loading.tsx
+++ b/app/scan/loading.tsx
@@ -93,7 +93,8 @@ const ScanLoadingScreen = () => {
           if (result.status === 'COMPLETED') {
             setIsComplete(true);
             return;
-          } else if (result.status === 'FAILED') {
+          }
+          if (result.status === 'FAILED') {
             Alert.alert('분석 실패', '문서 분석에 실패했어요. 다시 시도해주세요.', [
               { text: '확인', onPress: () => router.back() },
             ]);

--- a/app/scan/preview.tsx
+++ b/app/scan/preview.tsx
@@ -13,18 +13,21 @@ import layout from '../../src/constants/layout';
 import { SCAN_FRAME_W, SCAN_FRAME_H, SCAN_DEFAULT_CHILD_COLOR } from '../../src/constants/scan';
 
 const ScanPreviewScreen = () => {
-  const { photoUri, childId, childName, childColor, childGrade, source } = useLocalSearchParams<{
-    photoUri: string;
-    childId: string;
-    childName: string;
-    childColor: string;
-    childGrade: string;
-    source: 'camera' | 'gallery';
-  }>();
+  const { photoUri, childId, childName, childColor, childGrade, source, fileType } =
+    useLocalSearchParams<{
+      photoUri: string;
+      childId: string;
+      childName: string;
+      childColor: string;
+      childGrade: string;
+      source: 'camera' | 'gallery' | 'pdf';
+      fileType?: string;
+    }>();
   const insets = useSafeAreaInsets();
 
   const hasChild = !!childName;
-  const isPdf = photoUri?.toLowerCase().endsWith('.pdf');
+  const isPdf =
+    source === 'pdf' || fileType === 'application/pdf' || photoUri?.toLowerCase().endsWith('.pdf');
   const pdfFilename = photoUri?.split('/').pop() ?? 'document.pdf';
   const retakeLabel = source === 'gallery' || isPdf ? '다시 선택하기' : '다시 찍기';
 

--- a/app/scan/preview.tsx
+++ b/app/scan/preview.tsx
@@ -2,6 +2,7 @@ import { View, Image, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
+import React from 'react';
 import Header from '../../src/components/common/Header';
 import ScanStepIndicator from '../../src/components/scan/ScanStepIndicator';
 import ScanChildPill from '../../src/components/scan/ScanChildPill';
@@ -10,9 +11,8 @@ import colors from '../../src/constants/colors';
 import fonts from '../../src/constants/fonts';
 import layout from '../../src/constants/layout';
 import { SCAN_FRAME_W, SCAN_FRAME_H, SCAN_DEFAULT_CHILD_COLOR } from '../../src/constants/scan';
-import React from 'react';
 
-export default function ScanPreviewScreen() {
+const ScanPreviewScreen = () => {
   const { photoUri, childId, childName, childColor, childGrade, source } = useLocalSearchParams<{
     photoUri: string;
     childId: string;
@@ -84,7 +84,9 @@ export default function ScanPreviewScreen() {
       </View>
     </View>
   );
-}
+};
+
+export default ScanPreviewScreen;
 
 const styles = StyleSheet.create({
   screen: {

--- a/app/scan/preview.tsx
+++ b/app/scan/preview.tsx
@@ -1,6 +1,7 @@
 import { View, Image, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
 import Header from '../../src/components/common/Header';
 import ScanStepIndicator from '../../src/components/scan/ScanStepIndicator';
 import ScanChildPill from '../../src/components/scan/ScanChildPill';
@@ -9,10 +10,12 @@ import colors from '../../src/constants/colors';
 import fonts from '../../src/constants/fonts';
 import layout from '../../src/constants/layout';
 import { SCAN_FRAME_W, SCAN_FRAME_H, SCAN_DEFAULT_CHILD_COLOR } from '../../src/constants/scan';
+import React from 'react';
 
 export default function ScanPreviewScreen() {
-  const { photoUri, childName, childColor, childGrade, source } = useLocalSearchParams<{
+  const { photoUri, childId, childName, childColor, childGrade, source } = useLocalSearchParams<{
     photoUri: string;
+    childId: string;
     childName: string;
     childColor: string;
     childGrade: string;
@@ -21,7 +24,9 @@ export default function ScanPreviewScreen() {
   const insets = useSafeAreaInsets();
 
   const hasChild = !!childName;
-  const retakeLabel = source === 'gallery' ? '다시 선택하기' : '다시 찍기';
+  const isPdf = photoUri?.toLowerCase().endsWith('.pdf');
+  const pdfFilename = photoUri?.split('/').pop() ?? 'document.pdf';
+  const retakeLabel = source === 'gallery' || isPdf ? '다시 선택하기' : '다시 찍기';
 
   return (
     <View style={styles.screen}>
@@ -33,12 +38,22 @@ export default function ScanPreviewScreen() {
       )}
 
       <View style={styles.frameWrapper}>
-        <Image
-          source={{ uri: photoUri }}
-          style={styles.image}
-          resizeMode="cover"
-          accessibilityLabel="스캔할 문서 미리보기"
-        />
+        {isPdf ? (
+          <View style={styles.pdfPlaceholder}>
+            <Ionicons name="document-text-outline" size={48} color={colors.primary[400]} />
+            <Text style={styles.pdfFilename} numberOfLines={2}>
+              {pdfFilename}
+            </Text>
+            <Text style={styles.pdfLabel}>PDF 파일</Text>
+          </View>
+        ) : (
+          <Image
+            source={{ uri: photoUri }}
+            style={styles.image}
+            resizeMode="cover"
+            accessibilityLabel="스캔할 문서 미리보기"
+          />
+        )}
         <ScanCornerBrackets />
       </View>
 
@@ -57,7 +72,7 @@ export default function ScanPreviewScreen() {
           onPress={() =>
             router.push({
               pathname: '/scan/loading',
-              params: { photoUri, childName, childColor, childGrade },
+              params: { photoUri, childId, childName, childColor, childGrade },
             })
           }
           activeOpacity={0.8}
@@ -87,6 +102,26 @@ const styles = StyleSheet.create({
   image: {
     width: SCAN_FRAME_W,
     height: SCAN_FRAME_H,
+  },
+  pdfPlaceholder: {
+    width: SCAN_FRAME_W,
+    height: SCAN_FRAME_H,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    backgroundColor: colors.primary[0],
+  },
+  pdfFilename: {
+    fontSize: 14,
+    fontFamily: fonts.semiBold,
+    color: colors.text.primary,
+    textAlign: 'center',
+    paddingHorizontal: 16,
+  },
+  pdfLabel: {
+    fontSize: 12,
+    fontFamily: fonts.medium,
+    color: colors.text.secondary,
   },
   buttons: {
     flex: 1,

--- a/app/scan/result.tsx
+++ b/app/scan/result.tsx
@@ -142,6 +142,7 @@ export default function ScanResultScreen() {
         onConfirm={() => router.replace('/(tabs)/calendar')}
         onDismiss={() => router.replace('/(tabs)')}
         childName={displayChildName}
+        newsletterId={newsletterId}
       />
     </View>
   );

--- a/app/scan/result.tsx
+++ b/app/scan/result.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { View, Text, TouchableOpacity, ScrollView } from 'react-native';
+import { useEffect, useState } from 'react';
+import { View, Text, TouchableOpacity, ScrollView, ActivityIndicator } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -9,24 +9,25 @@ import FullDocTab from '../../src/components/scan/result/FullDocTab';
 import ChecklistTab from '../../src/components/scan/result/ChecklistTab';
 import AISummaryTab from '../../src/components/scan/result/AISummaryTab';
 import SaveBottomSheet from '../../src/components/scan/result/SaveBottomSheet';
+import { getNewsletterDetail, type NewsletterDetail } from '../../src/api/newsletter';
 import colors from '../../src/constants/colors';
 import styles from '../../src/styles/scan/result';
 
 const TABS = ['전체 문서', '체크리스트', 'AI 요약'] as const;
 type Tab = (typeof TABS)[number];
 
-const MOCK_DOC = {
-  title: '봄 현장학습 안내 및 동의서 제출 요청',
-  date: '2026년 5월 22일',
-  daysLeft: 7,
+const formatDate = (iso: string) => {
+  const d = new Date(iso);
+  return `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일`;
 };
 
 export default function ScanResultScreen() {
-  const { photoUri, childName, childGrade } = useLocalSearchParams<{
-    photoUri: string;
+  const { childName: childNameParam, childGrade, newsletterId: newsletterIdParam } = useLocalSearchParams<{
     childName: string;
     childGrade: string;
+    newsletterId: string;
   }>();
+  const newsletterId = newsletterIdParam ? Number(newsletterIdParam) : undefined;
 
   const router = useRouter();
   const insets = useSafeAreaInsets();
@@ -34,29 +35,56 @@ export default function ScanResultScreen() {
   const [helpVisible, setHelpVisible] = useState(false);
   const [saveVisible, setSaveVisible] = useState(false);
 
-  const { daysLeft } = MOCK_DOC;
+  const [detail, setDetail] = useState<NewsletterDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(!!newsletterIdParam);
+
+  useEffect(() => {
+    if (!newsletterId) {
+      setDetailLoading(false);
+      return;
+    }
+    getNewsletterDetail(newsletterId)
+      .then(setDetail)
+      .catch(() => {
+        // 헤더 정보 로드 실패 시 route param fallback으로 표시
+      })
+      .finally(() => setDetailLoading(false));
+  }, [newsletterId]);
+
+  const displayTitle = detail?.title ?? '';
+  const displayChildName = detail?.childName ?? childNameParam ?? '';
+  const displayDate = detail ? formatDate(detail.createdAt) : '';
 
   return (
     <View style={styles.screen}>
       <Header title="스캔 결과" onHelp={() => setHelpVisible(true)} />
 
       <View style={styles.docInfo}>
-        <Text style={styles.docTitle}>{MOCK_DOC.title}</Text>
-        <View style={styles.metaRow}>
-          <View style={styles.metaItem}>
-            <Ionicons name="calendar" size={13} color={colors.text.secondary} />
-            <Text style={styles.metaText}>{MOCK_DOC.date}</Text>
-          </View>
-          <View style={styles.metaItem}>
-            <Ionicons name="school" size={13} color={colors.text.secondary} />
-            <Text style={styles.metaText}>
-              {childName ?? ''} · {childGrade ?? ''}
-            </Text>
-          </View>
-          <View style={[styles.dBadge, daysLeft <= 3 && styles.dBadgeUrgent]}>
-            <Text style={styles.dBadgeText}>D-{daysLeft}</Text>
-          </View>
-        </View>
+        {detailLoading ? (
+          <ActivityIndicator size="small" color={colors.primary[400]} />
+        ) : (
+          <>
+            <Text style={styles.docTitle}>{displayTitle}</Text>
+            <View style={styles.metaRow}>
+              {displayDate ? (
+                <View style={styles.metaItem}>
+                  <Ionicons name="calendar" size={13} color={colors.text.secondary} />
+                  <Text style={styles.metaText}>{displayDate}</Text>
+                </View>
+              ) : null}
+              {(displayChildName || childGrade) ? (
+                <View style={styles.metaItem}>
+                  <Ionicons name="school" size={13} color={colors.text.secondary} />
+                  <Text style={styles.metaText}>
+                    {displayChildName}
+                    {displayChildName && childGrade ? ' · ' : ''}
+                    {childGrade ?? ''}
+                  </Text>
+                </View>
+              ) : null}
+            </View>
+          </>
+        )}
       </View>
 
       <View style={styles.tabBar}>
@@ -80,9 +108,9 @@ export default function ScanResultScreen() {
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator
       >
-        {activeTab === '전체 문서' && <FullDocTab photoUri={photoUri ?? ''} />}
-        {activeTab === '체크리스트' && <ChecklistTab />}
-        {activeTab === 'AI 요약' && <AISummaryTab />}
+        {activeTab === '전체 문서' && <FullDocTab newsletterId={newsletterId} />}
+        {activeTab === '체크리스트' && <ChecklistTab newsletterId={newsletterId} />}
+        {activeTab === 'AI 요약' && <AISummaryTab newsletterId={newsletterId} />}
       </ScrollView>
 
       <View style={[styles.bottomBar, { paddingBottom: insets.bottom + 12 }]}>
@@ -113,7 +141,7 @@ export default function ScanResultScreen() {
         onClose={() => setSaveVisible(false)}
         onConfirm={() => router.replace('/(tabs)/calendar')}
         onDismiss={() => router.replace('/(tabs)')}
-        childName={childName ?? ''}
+        childName={displayChildName}
       />
     </View>
   );

--- a/app/scan/result.tsx
+++ b/app/scan/result.tsx
@@ -46,7 +46,7 @@ const ScanResultScreen = () => {
     if (!newsletterId) {
       setDetail(null);
       setDetailLoading(false);
-      return;
+      return () => {};
     }
     let cancelled = false;
     setDetail(null);

--- a/app/scan/result.tsx
+++ b/app/scan/result.tsx
@@ -21,8 +21,12 @@ const formatDate = (iso: string) => {
   return `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일`;
 };
 
-export default function ScanResultScreen() {
-  const { childName: childNameParam, childGrade, newsletterId: newsletterIdParam } = useLocalSearchParams<{
+const ScanResultScreen = () => {
+  const {
+    childName: childNameParam,
+    childGrade,
+    newsletterId: newsletterIdParam,
+  } = useLocalSearchParams<{
     childName: string;
     childGrade: string;
     newsletterId: string;
@@ -72,7 +76,7 @@ export default function ScanResultScreen() {
                   <Text style={styles.metaText}>{displayDate}</Text>
                 </View>
               ) : null}
-              {(displayChildName || childGrade) ? (
+              {displayChildName || childGrade ? (
                 <View style={styles.metaItem}>
                   <Ionicons name="school" size={13} color={colors.text.secondary} />
                   <Text style={styles.metaText}>
@@ -146,4 +150,6 @@ export default function ScanResultScreen() {
       />
     </View>
   );
-}
+};
+
+export default ScanResultScreen;

--- a/app/scan/result.tsx
+++ b/app/scan/result.tsx
@@ -44,15 +44,28 @@ const ScanResultScreen = () => {
 
   useEffect(() => {
     if (!newsletterId) {
+      setDetail(null);
       setDetailLoading(false);
       return;
     }
+    let cancelled = false;
+    setDetail(null);
+    setDetailLoading(true);
+
     getNewsletterDetail(newsletterId)
-      .then(setDetail)
-      .catch(() => {
-        // 헤더 정보 로드 실패 시 route param fallback으로 표시
+      .then((data) => {
+        if (!cancelled) setDetail(data);
       })
-      .finally(() => setDetailLoading(false));
+      .catch(() => {
+        if (!cancelled) setDetail(null);
+      })
+      .finally(() => {
+        if (!cancelled) setDetailLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [newsletterId]);
 
   const displayTitle = detail?.title ?? '';

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "expo": "~55.0.14",
         "expo-camera": "~55.0.15",
         "expo-constants": "~55.0.13",
+        "expo-document-picker": "~55.0.13",
         "expo-file-system": "~55.0.16",
         "expo-font": "~55.0.6",
         "expo-image-manipulator": "~55.0.15",
@@ -39,6 +40,7 @@
         "react-native-safe-area-context": "~5.6.2",
         "react-native-screens": "~4.23.0",
         "react-native-svg": "15.15.3",
+        "react-native-webview": "13.16.0",
         "react-native-worklets": "0.7.2",
         "zod": "^4.3.6",
         "zustand": "^5.0.12"
@@ -6553,6 +6555,15 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-document-picker": {
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-55.0.13.tgz",
+      "integrity": "sha512-IhswJElhdzs3fKDEKW8KXYRoFkWGEsXRMYAZT46Yo56zqqy8yQXrczo33RSwD2hFzNQBdLT97SJL9N311UyS3g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-file-system": {
       "version": "55.0.16",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-55.0.16.tgz",
@@ -10741,6 +10752,20 @@
       "resolved": "https://registry.npmjs.org/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz",
       "integrity": "sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==",
       "license": "MIT"
+    },
+    "node_modules/react-native-webview": {
+      "version": "13.16.0",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.16.0.tgz",
+      "integrity": "sha512-Nh13xKZWW35C0dbOskD7OX01nQQavOzHbCw9XoZmar4eXCo7AvrYJ0jlUfRVVIJzqINxHlpECYLdmAdFsl9xDA==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/react-native-worklets": {
       "version": "0.7.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "expo": "~55.0.14",
     "expo-camera": "~55.0.15",
     "expo-constants": "~55.0.13",
+    "expo-document-picker": "~55.0.13",
     "expo-file-system": "~55.0.16",
     "expo-font": "~55.0.6",
     "expo-image-manipulator": "~55.0.15",
@@ -43,6 +44,7 @@
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.23.0",
     "react-native-svg": "15.15.3",
+    "react-native-webview": "13.16.0",
     "react-native-worklets": "0.7.2",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"

--- a/src/api/calendar.ts
+++ b/src/api/calendar.ts
@@ -142,6 +142,73 @@ export const fetchWeeklyEvents = async (
   }
 };
 
+export interface CalendarPreviewItem {
+  tempEventId: number;
+  title: string;
+  extractedDate: string | null;
+  isDateExtracted: boolean;
+}
+
+export const getCalendarPreview = async (
+  newsletterId: number
+): Promise<CalendarPreviewItem[]> => {
+  try {
+    const headers = await getAuthHeader();
+    const response = await apiClient.get<{ result: { items: CalendarPreviewItem[] } }>(
+      `/api/v1/newsletters/${newsletterId}/calendar/preview`,
+      { headers }
+    );
+    return response.data.result.items;
+  } catch (error) {
+    throw wrapError(error);
+  }
+};
+
+export interface CalendarDatePatchEvent {
+  tempEventId: number;
+  correctedDate: string;
+}
+
+export const patchCalendarPreviewDates = async (
+  newsletterId: number,
+  events: CalendarDatePatchEvent[]
+): Promise<void> => {
+  try {
+    const headers = await getAuthHeader();
+    await apiClient.patch(
+      `/api/v1/newsletters/${newsletterId}/calendar/preview/dates`,
+      { events },
+      { headers }
+    );
+  } catch (error) {
+    throw wrapError(error);
+  }
+};
+
+export interface CalendarPostEvent {
+  tempEventId: number;
+  title: string;
+  startAt: string;
+  endAt: string | null;
+}
+
+export const postCalendarEvents = async (
+  newsletterId: number,
+  events: CalendarPostEvent[]
+): Promise<{ registeredCount: number }> => {
+  try {
+    const headers = await getAuthHeader();
+    const response = await apiClient.post<{ result: { registeredCount: number } }>(
+      `/api/v1/newsletters/${newsletterId}/calendar`,
+      { events },
+      { headers }
+    );
+    return response.data.result;
+  } catch (error) {
+    throw wrapError(error);
+  }
+};
+
 export const completeChecklist = async (
   checklistId: number,
   isCompleted: boolean

--- a/src/api/calendar.ts
+++ b/src/api/calendar.ts
@@ -149,9 +149,7 @@ export interface CalendarPreviewItem {
   isDateExtracted: boolean;
 }
 
-export const getCalendarPreview = async (
-  newsletterId: number
-): Promise<CalendarPreviewItem[]> => {
+export const getCalendarPreview = async (newsletterId: number): Promise<CalendarPreviewItem[]> => {
   try {
     const headers = await getAuthHeader();
     const response = await apiClient.get<{ result: { items: CalendarPreviewItem[] } }>(

--- a/src/api/child.ts
+++ b/src/api/child.ts
@@ -1,4 +1,6 @@
 import axios from 'axios';
+import * as SecureStore from 'expo-secure-store';
+import { apiClient } from './auth';
 
 export class ChildApiError extends Error {
   constructor(
@@ -25,6 +27,12 @@ const childApiClient = axios.create({
   headers: { 'Content-Type': 'application/json' },
   timeout: 10000,
 });
+
+const getAuthHeader = async () => {
+  const token = await SecureStore.getItemAsync('accessToken');
+  if (!token) throw new ChildApiError('UNAUTHORIZED', '로그인이 필요합니다.');
+  return { Authorization: `Bearer ${token}` };
+};
 
 export interface ChildPayload {
   name: string;
@@ -71,6 +79,18 @@ export const registerChildren = async (
       )
     );
     return results.map((res) => res.data.result);
+  } catch (error) {
+    throw wrapError(error);
+  }
+};
+
+export const getMyChildren = async (): Promise<ChildResult[]> => {
+  try {
+    const headers = await getAuthHeader();
+    const response = await apiClient.get<{ result: ChildResult[] }>('/api/v1/children', {
+      headers,
+    });
+    return response.data.result ?? [];
   } catch (error) {
     throw wrapError(error);
   }

--- a/src/api/newsletter.ts
+++ b/src/api/newsletter.ts
@@ -157,9 +157,7 @@ export interface NewsletterDetail {
   createdAt: string;
 }
 
-export const getNewsletterDetail = async (
-  newsletterId: number
-): Promise<NewsletterDetail> => {
+export const getNewsletterDetail = async (newsletterId: number): Promise<NewsletterDetail> => {
   try {
     const headers = await getAuthHeader();
     const response = await apiClient.get<{ result: NewsletterDetail }>(

--- a/src/api/newsletter.ts
+++ b/src/api/newsletter.ts
@@ -1,0 +1,208 @@
+import axios from 'axios';
+import * as SecureStore from 'expo-secure-store';
+import { apiClient } from './auth';
+
+export type NewsletterStatus = 'PENDING' | 'PROCESSING' | 'COMPLETED' | 'FAILED';
+
+export interface NewsletterStatusResult {
+  status: NewsletterStatus;
+  progressPercent: number;
+  progressMessage: string;
+}
+
+export class NewsletterApiError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string
+  ) {
+    super(message);
+    this.name = 'NewsletterApiError';
+  }
+}
+
+const wrapError = (error: unknown): Error => {
+  if (axios.isAxiosError(error) && error.response?.data?.code) {
+    return new NewsletterApiError(
+      error.response.data.code,
+      error.response.data.message ?? '알 수 없는 오류'
+    );
+  }
+  return error instanceof Error ? error : new Error(String(error));
+};
+
+const getAuthHeader = async () => {
+  const token = await SecureStore.getItemAsync('accessToken');
+  if (!token) throw new NewsletterApiError('UNAUTHORIZED', '로그인이 필요합니다.');
+  return { Authorization: `Bearer ${token}` };
+};
+
+interface RNFile {
+  uri: string;
+  name: string;
+  type: string;
+}
+
+const getMimeType = (uri: string) => {
+  const ext = uri.split('.').pop()?.toLowerCase();
+  if (ext === 'pdf') return 'application/pdf';
+  if (ext === 'png') return 'image/png';
+  return 'image/jpeg';
+};
+
+export const uploadNewsletter = async (
+  photoUri: string,
+  childId?: number
+): Promise<{ newsletterId: number; status: NewsletterStatus }> => {
+  try {
+    const authHeaders = await getAuthHeader();
+    const filename = photoUri.split('/').pop() ?? 'scan.jpg';
+
+    const mimeType = getMimeType(photoUri);
+    const filePayload: RNFile = { uri: photoUri, name: filename, type: mimeType };
+    const formData = new FormData();
+    formData.append('file', filePayload as unknown as Blob);
+
+    const params: Record<string, unknown> = { language: 'KO' };
+    if (childId !== undefined && !Number.isNaN(childId)) {
+      params.childId = childId;
+    }
+
+    const response = await apiClient.post<{
+      result: { newsletterId: number; status: NewsletterStatus };
+    }>('/api/v1/newsletters', formData, {
+      headers: {
+        ...authHeaders,
+        'Content-Type': 'multipart/form-data',
+      },
+      params,
+      timeout: 60000,
+    });
+
+    return response.data.result;
+  } catch (error) {
+    throw wrapError(error);
+  }
+};
+
+export interface DateCandidate {
+  originalText: string;
+  normalizedDate: string;
+  startOffset: number;
+  endOffset: number;
+  extractionType: string;
+}
+
+export interface NewsletterTranslationResult {
+  originalText: string;
+  translatedText?: string;
+  language: string;
+  fileUrl: string;
+  dateCandidates?: DateCandidate[];
+}
+
+export const getNewsletterTranslation = async (
+  newsletterId: number
+): Promise<NewsletterTranslationResult> => {
+  try {
+    const headers = await getAuthHeader();
+    const response = await apiClient.get<{ result: NewsletterTranslationResult }>(
+      `/api/v1/newsletters/${newsletterId}/translation`,
+      { headers }
+    );
+    return response.data.result;
+  } catch (error) {
+    throw wrapError(error);
+  }
+};
+
+export type ChecklistItemType = 'CHECKLIST' | 'TODO';
+
+export interface ChecklistItem {
+  checklistId: number;
+  type: ChecklistItemType;
+  content: string;
+  detail: string | null;
+  isCompleted: boolean;
+  targetDate: string | null;
+  targetDateLabel: string | null;
+}
+
+export const getNewsletterChecklist = async (
+  newsletterId: number,
+  type?: ChecklistItemType
+): Promise<ChecklistItem[]> => {
+  try {
+    const headers = await getAuthHeader();
+    const params: Record<string, string> = {};
+    if (type) params.type = type;
+    const response = await apiClient.get<{ result: { items: ChecklistItem[] } }>(
+      `/api/v1/newsletters/${newsletterId}/checklist`,
+      { headers, params }
+    );
+    return response.data.result.items;
+  } catch (error) {
+    throw wrapError(error);
+  }
+};
+
+export interface NewsletterDetail {
+  newsletterId: number;
+  title: string;
+  childName: string;
+  summary: string;
+  originalText: string;
+  translatedText: string | null;
+  language: string;
+  isCalendarRegistered: boolean;
+  createdAt: string;
+}
+
+export const getNewsletterDetail = async (
+  newsletterId: number
+): Promise<NewsletterDetail> => {
+  try {
+    const headers = await getAuthHeader();
+    const response = await apiClient.get<{ result: NewsletterDetail }>(
+      `/api/v1/newsletters/${newsletterId}`,
+      { headers }
+    );
+    return response.data.result;
+  } catch (error) {
+    throw wrapError(error);
+  }
+};
+
+export interface NewsletterSummaryResult {
+  title: string;
+  summary: string;
+}
+
+export const getNewsletterSummary = async (
+  newsletterId: number
+): Promise<NewsletterSummaryResult> => {
+  try {
+    const headers = await getAuthHeader();
+    const response = await apiClient.get<{ result: NewsletterSummaryResult }>(
+      `/api/v1/newsletters/${newsletterId}/summary`,
+      { headers }
+    );
+    return response.data.result;
+  } catch (error) {
+    throw wrapError(error);
+  }
+};
+
+export const getNewsletterStatus = async (
+  newsletterId: number
+): Promise<NewsletterStatusResult> => {
+  try {
+    const headers = await getAuthHeader();
+    const response = await apiClient.get<{ result: NewsletterStatusResult }>(
+      `/api/v1/newsletters/${newsletterId}/status`,
+      { headers }
+    );
+    return response.data.result;
+  } catch (error) {
+    throw wrapError(error);
+  }
+};

--- a/src/components/scan/result/AISummaryTab.tsx
+++ b/src/components/scan/result/AISummaryTab.tsx
@@ -39,7 +39,7 @@ const mapSummaryError = (e: unknown): string => {
   return '요약을 불러오는 데 실패했어요.';
 };
 
-export default function AISummaryTab({ newsletterId }: Props) {
+const AISummaryTab = ({ newsletterId }: Props) => {
   const [summary, setSummary] = useState<NewsletterSummaryResult | null>(null);
   const [summaryLoading, setSummaryLoading] = useState(true);
   const [summaryError, setSummaryError] = useState<string | null>(null);
@@ -54,18 +54,26 @@ export default function AISummaryTab({ newsletterId }: Props) {
       setSummaryLoading(false);
       setTodoError('가정통신문 정보를 찾을 수 없어요.');
       setTodoLoading(false);
-      return;
+      return () => {};
     }
 
     let cancelled = false;
 
     getNewsletterSummary(newsletterId)
-      .then((data) => { if (!cancelled) setSummary(data); })
-      .catch((e) => { if (!cancelled) setSummaryError(mapSummaryError(e)); })
-      .finally(() => { if (!cancelled) setSummaryLoading(false); });
+      .then((data) => {
+        if (!cancelled) setSummary(data);
+      })
+      .catch((e) => {
+        if (!cancelled) setSummaryError(mapSummaryError(e));
+      })
+      .finally(() => {
+        if (!cancelled) setSummaryLoading(false);
+      });
 
     getNewsletterChecklist(newsletterId, 'TODO')
-      .then((data) => { if (!cancelled) setTodos(data); })
+      .then((data) => {
+        if (!cancelled) setTodos(data);
+      })
       .catch((e) => {
         if (cancelled) return;
         if (e instanceof NewsletterApiError && e.code === 'NL4041') {
@@ -74,51 +82,56 @@ export default function AISummaryTab({ newsletterId }: Props) {
           setTodoError('할 일 목록을 불러오는 데 실패했어요.');
         }
       })
-      .finally(() => { if (!cancelled) setTodoLoading(false); });
+      .finally(() => {
+        if (!cancelled) setTodoLoading(false);
+      });
 
     return () => {
       cancelled = true;
     };
   }, [newsletterId]);
 
+  const renderSummary = () => {
+    if (summaryLoading) return <ActivityIndicator size="small" color={colors.primary[400]} />;
+    if (summaryError) return <Text style={styles.errorText}>{summaryError}</Text>;
+    if (summary)
+      return (
+        <>
+          <Text style={styles.summaryTitle}>{summary.title}</Text>
+          <Text style={styles.body}>{summary.summary}</Text>
+        </>
+      );
+    return null;
+  };
+
+  const renderTodos = () => {
+    if (todoLoading) return <ActivityIndicator size="small" color={colors.primary[400]} />;
+    if (todoError) return <Text style={styles.errorText}>{todoError}</Text>;
+    if (todos.length === 0) return <Text style={styles.errorText}>등록된 할 일이 없어요.</Text>;
+    return (
+      <View style={styles.todoList}>
+        {todos.map((item) => (
+          <View key={item.checklistId} style={styles.todoItem}>
+            <View style={styles.bullet} />
+            <Text style={styles.todoText}>
+              {item.targetDateLabel && <Text style={styles.todoWhen}>{item.targetDateLabel}</Text>}
+              {item.targetDateLabel ? ' — ' : ''}
+              {item.content}
+            </Text>
+          </View>
+        ))}
+      </View>
+    );
+  };
+
   return (
     <View style={styles.list}>
       <SummaryCard icon="bulb-outline" iconBg={colors.primary[400]} title="AI 요약">
-        {summaryLoading ? (
-          <ActivityIndicator size="small" color={colors.primary[400]} />
-        ) : summaryError ? (
-          <Text style={styles.errorText}>{summaryError}</Text>
-        ) : summary ? (
-          <>
-            <Text style={styles.summaryTitle}>{summary.title}</Text>
-            <Text style={styles.body}>{summary.summary}</Text>
-          </>
-        ) : null}
+        {renderSummary()}
       </SummaryCard>
 
       <SummaryCard icon="alarm-outline" iconBg={colors.secondary[600]} title="오늘 할 일">
-        {todoLoading ? (
-          <ActivityIndicator size="small" color={colors.primary[400]} />
-        ) : todoError ? (
-          <Text style={styles.errorText}>{todoError}</Text>
-        ) : todos.length === 0 ? (
-          <Text style={styles.errorText}>등록된 할 일이 없어요.</Text>
-        ) : (
-          <View style={styles.todoList}>
-            {todos.map((item) => (
-              <View key={item.checklistId} style={styles.todoItem}>
-                <View style={styles.bullet} />
-                <Text style={styles.todoText}>
-                  {item.targetDateLabel && (
-                    <Text style={styles.todoWhen}>{item.targetDateLabel}</Text>
-                  )}
-                  {item.targetDateLabel ? ' — ' : ''}
-                  {item.content}
-                </Text>
-              </View>
-            ))}
-          </View>
-        )}
+        {renderTodos()}
       </SummaryCard>
 
       <SummaryCard icon="earth-outline" iconBg={colors.primary[400]} title="문화 맥락 안내">
@@ -143,7 +156,9 @@ export default function AISummaryTab({ newsletterId }: Props) {
       </SummaryCard>
     </View>
   );
-}
+};
+
+export default AISummaryTab;
 
 const styles = StyleSheet.create({
   list: {

--- a/src/components/scan/result/AISummaryTab.tsx
+++ b/src/components/scan/result/AISummaryTab.tsx
@@ -49,6 +49,13 @@ const AISummaryTab = ({ newsletterId }: Props) => {
   const [todoError, setTodoError] = useState<string | null>(null);
 
   useEffect(() => {
+    setSummary(null);
+    setSummaryLoading(true);
+    setSummaryError(null);
+    setTodos([]);
+    setTodoLoading(true);
+    setTodoError(null);
+
     if (!newsletterId) {
       setSummaryError('가정통신문 정보를 찾을 수 없어요.');
       setSummaryLoading(false);
@@ -61,7 +68,10 @@ const AISummaryTab = ({ newsletterId }: Props) => {
 
     getNewsletterSummary(newsletterId)
       .then((data) => {
-        if (!cancelled) setSummary(data);
+        if (!cancelled) {
+          setSummary(data);
+          setSummaryError(null);
+        }
       })
       .catch((e) => {
         if (!cancelled) setSummaryError(mapSummaryError(e));
@@ -72,7 +82,10 @@ const AISummaryTab = ({ newsletterId }: Props) => {
 
     getNewsletterChecklist(newsletterId, 'TODO')
       .then((data) => {
-        if (!cancelled) setTodos(data);
+        if (!cancelled) {
+          setTodos(data);
+          setTodoError(null);
+        }
       })
       .catch((e) => {
         if (cancelled) return;

--- a/src/components/scan/result/AISummaryTab.tsx
+++ b/src/components/scan/result/AISummaryTab.tsx
@@ -1,13 +1,18 @@
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
 import SummaryCard from './SummaryCard';
+import {
+  getNewsletterSummary,
+  getNewsletterChecklist,
+  NewsletterApiError,
+} from '../../../api/newsletter';
+import type { NewsletterSummaryResult, ChecklistItem } from '../../../api/newsletter';
 import colors from '../../../constants/colors';
 import fonts from '../../../constants/fonts';
 
-const TODO_ITEMS = [
-  { when: '지금 바로', desc: '동의서에 서명 후 내일 가방에 넣어두기' },
-  { when: '내일', desc: '담임 선생님께 동의서 직접 제출' },
-  { when: '5월 21일', desc: '도시락, 체육복, 물병 준비' },
-];
+interface Props {
+  newsletterId?: number;
+}
 
 const QNA_ITEMS = [
   {
@@ -24,45 +29,102 @@ const QNA_ITEMS = [
   },
 ];
 
-export default function AISummaryTab() {
+const mapSummaryError = (e: unknown): string => {
+  if (e instanceof NewsletterApiError) {
+    if (e.code === 'NL4092') return '아직 분석 중인 가정통신문이에요.';
+    if (e.code === 'NL4221') return '분석에 실패한 가정통신문이에요.';
+    if (e.code === 'NL4041') return '가정통신문을 찾을 수 없어요.';
+    if (e.code === 'NL4031') return '접근 권한이 없어요.';
+  }
+  return '요약을 불러오는 데 실패했어요.';
+};
+
+export default function AISummaryTab({ newsletterId }: Props) {
+  const [summary, setSummary] = useState<NewsletterSummaryResult | null>(null);
+  const [summaryLoading, setSummaryLoading] = useState(true);
+  const [summaryError, setSummaryError] = useState<string | null>(null);
+
+  const [todos, setTodos] = useState<ChecklistItem[]>([]);
+  const [todoLoading, setTodoLoading] = useState(true);
+  const [todoError, setTodoError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!newsletterId) {
+      setSummaryError('가정통신문 정보를 찾을 수 없어요.');
+      setSummaryLoading(false);
+      setTodoError('가정통신문 정보를 찾을 수 없어요.');
+      setTodoLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    getNewsletterSummary(newsletterId)
+      .then((data) => { if (!cancelled) setSummary(data); })
+      .catch((e) => { if (!cancelled) setSummaryError(mapSummaryError(e)); })
+      .finally(() => { if (!cancelled) setSummaryLoading(false); });
+
+    getNewsletterChecklist(newsletterId, 'TODO')
+      .then((data) => { if (!cancelled) setTodos(data); })
+      .catch((e) => {
+        if (cancelled) return;
+        if (e instanceof NewsletterApiError && e.code === 'NL4041') {
+          setTodoError('가정통신문을 찾을 수 없어요.');
+        } else {
+          setTodoError('할 일 목록을 불러오는 데 실패했어요.');
+        }
+      })
+      .finally(() => { if (!cancelled) setTodoLoading(false); });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [newsletterId]);
+
   return (
     <View style={styles.list}>
       <SummaryCard icon="bulb-outline" iconBg={colors.primary[400]} title="AI 요약">
-        <Text style={styles.body}>
-          {'첫째 반이 '}
-          <Text style={styles.highlight}>5월 22일 목요일</Text>
-          {'에 '}
-          <Text style={styles.highlight}>국립민속박물관과 경복궁</Text>
-          {
-            '으로 봄 현장학습을 가요. 전일 체험학습이라 학교 점심 급식이 없으니 도시락을 꼭 챙겨야 해요.'
-          }
-        </Text>
-        <Text style={styles.body}>
-          {'가장 중요한 건 '}
-          <Text style={styles.highlight}>동의서를 오늘(5월 15일)까지</Text>
-          {' 담임 선생님께 직접 제출하는 것이에요.'}
-        </Text>
+        {summaryLoading ? (
+          <ActivityIndicator size="small" color={colors.primary[400]} />
+        ) : summaryError ? (
+          <Text style={styles.errorText}>{summaryError}</Text>
+        ) : summary ? (
+          <>
+            <Text style={styles.summaryTitle}>{summary.title}</Text>
+            <Text style={styles.body}>{summary.summary}</Text>
+          </>
+        ) : null}
       </SummaryCard>
 
       <SummaryCard icon="alarm-outline" iconBg={colors.secondary[600]} title="오늘 할 일">
-        <View style={styles.todoList}>
-          {TODO_ITEMS.map((item, i) => (
-            <View key={String(i)} style={styles.todoItem}>
-              <View style={styles.bullet} />
-              <Text style={styles.todoText}>
-                <Text style={styles.todoWhen}>{item.when}</Text>
-                {' — '}
-                {item.desc}
-              </Text>
-            </View>
-          ))}
-        </View>
+        {todoLoading ? (
+          <ActivityIndicator size="small" color={colors.primary[400]} />
+        ) : todoError ? (
+          <Text style={styles.errorText}>{todoError}</Text>
+        ) : todos.length === 0 ? (
+          <Text style={styles.errorText}>등록된 할 일이 없어요.</Text>
+        ) : (
+          <View style={styles.todoList}>
+            {todos.map((item) => (
+              <View key={item.checklistId} style={styles.todoItem}>
+                <View style={styles.bullet} />
+                <Text style={styles.todoText}>
+                  {item.targetDateLabel && (
+                    <Text style={styles.todoWhen}>{item.targetDateLabel}</Text>
+                  )}
+                  {item.targetDateLabel ? ' — ' : ''}
+                  {item.content}
+                </Text>
+              </View>
+            ))}
+          </View>
+        )}
       </SummaryCard>
 
       <SummaryCard icon="earth-outline" iconBg={colors.primary[400]} title="문화 맥락 안내">
         <View style={styles.qnaList}>
-          {QNA_ITEMS.map((item, i) => (
-            <View key={String(i)} style={styles.qnaItem}>
+          {QNA_ITEMS.map((item) => (
+            <View key={item.q} style={styles.qnaItem}>
               <View style={styles.qnaRow}>
                 <Text style={styles.qLabel}>Q.</Text>
                 <Text style={styles.qText}>{item.q}</Text>
@@ -87,15 +149,21 @@ const styles = StyleSheet.create({
   list: {
     gap: 16,
   },
+  summaryTitle: {
+    fontSize: 15,
+    fontFamily: fonts.semiBold,
+    color: colors.text.primary,
+  },
   body: {
     fontSize: 14,
     fontFamily: fonts.regular,
     color: colors.text.primary,
     lineHeight: 22,
   },
-  highlight: {
-    fontFamily: fonts.semiBold,
-    color: colors.primary[500],
+  errorText: {
+    fontSize: 14,
+    fontFamily: fonts.medium,
+    color: colors.text.secondary,
   },
   todoList: {
     gap: 10,

--- a/src/components/scan/result/ChecklistTab.tsx
+++ b/src/components/scan/result/ChecklistTab.tsx
@@ -1,91 +1,117 @@
-import { useState } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useEffect, useState } from 'react';
+import { View, Text, TouchableOpacity, ActivityIndicator, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import {
+  getNewsletterChecklist,
+  NewsletterApiError,
+} from '../../../api/newsletter';
+import type { ChecklistItem } from '../../../api/newsletter';
 import colors from '../../../constants/colors';
 import fonts from '../../../constants/fonts';
 
-interface ChecklistItem {
-  id: string;
-  title: string;
-  subtitle: string;
-  deadline?: string;
-  checked: boolean;
+interface Props {
+  newsletterId?: number;
 }
 
-const MOCK_ITEMS: ChecklistItem[] = [
-  {
-    id: '1',
-    title: '현장학습 동의서 제출',
-    subtitle: '담임 선생님께 원본 직접 제출',
-    deadline: '내일 마감',
-    checked: false,
-  },
-  {
-    id: '2',
-    title: '알레르기 없는 도시락 준비',
-    subtitle: '해산물, 견과류 포함 금지',
-    deadline: '내일 마감',
-    checked: false,
-  },
-  {
-    id: '3',
-    title: '봄 현장학습 안내문 읽기',
-    subtitle: 'AI 번역 완료',
-    deadline: '오늘 마감',
-    checked: true,
-  },
-  {
-    id: '4',
-    title: '현장학습 동의서 제출',
-    subtitle: '담임 선생님께 원본 직접 제출',
-    deadline: '내일 마감',
-    checked: false,
-  },
-];
+export default function ChecklistTab({ newsletterId }: Props) {
+  const [items, setItems] = useState<ChecklistItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-export default function ChecklistTab() {
-  const [items, setItems] = useState<ChecklistItem[]>(MOCK_ITEMS);
+  useEffect(() => {
+    if (!newsletterId) {
+      setError('가정통신문 정보를 찾을 수 없어요.');
+      setLoading(false);
+      return;
+    }
 
-  const toggle = (id: string) => {
+    let cancelled = false;
+
+    getNewsletterChecklist(newsletterId, 'CHECKLIST')
+      .then((result) => {
+        if (!cancelled) setItems(result);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        if (e instanceof NewsletterApiError && e.code === 'NL4041') {
+          setError('가정통신문을 찾을 수 없어요.');
+        } else {
+          setError('체크리스트를 불러오는 데 실패했어요.');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [newsletterId]);
+
+  const toggle = (id: number) => {
     setItems((prev) =>
-      prev.map((item) => (item.id === id ? { ...item, checked: !item.checked } : item))
+      prev.map((item) =>
+        item.checklistId === id ? { ...item, isCompleted: !item.isCompleted } : item
+      )
     );
   };
 
-  const remove = (id: string) => {
-    setItems((prev) => prev.filter((item) => item.id !== id));
+  const remove = (id: number) => {
+    setItems((prev) => prev.filter((item) => item.checklistId !== id));
   };
+
+  if (loading) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" color={colors.primary[400]} />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.errorText}>{error}</Text>
+      </View>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.errorText}>체크리스트 항목이 없어요.</Text>
+      </View>
+    );
+  }
 
   return (
     <View style={styles.list}>
       {items.map((item) => (
-        <View key={item.id} style={[styles.card, item.checked && styles.cardChecked]}>
+        <View key={item.checklistId} style={[styles.card, item.isCompleted && styles.cardChecked]}>
           <TouchableOpacity
-            style={[styles.checkbox, item.checked && styles.checkboxChecked]}
-            onPress={() => toggle(item.id)}
+            style={[styles.checkbox, item.isCompleted && styles.checkboxChecked]}
+            onPress={() => toggle(item.checklistId)}
             accessibilityRole="checkbox"
-            accessibilityState={{ checked: item.checked }}
+            accessibilityState={{ checked: item.isCompleted }}
           >
-            {item.checked && <Ionicons name="checkmark" size={14} color={colors.text.white} />}
+            {item.isCompleted && <Ionicons name="checkmark" size={14} color={colors.text.white} />}
           </TouchableOpacity>
 
           <View style={styles.textBlock}>
-            <Text style={[styles.title, item.checked && styles.titleChecked]}>{item.title}</Text>
-            <Text style={styles.subtitle}>{item.subtitle}</Text>
+            <Text style={[styles.title, item.isCompleted && styles.titleChecked]}>
+              {item.content}
+            </Text>
+            {item.detail && <Text style={styles.subtitle}>{item.detail}</Text>}
           </View>
 
-          {item.checked ? (
+          {item.isCompleted ? (
             <TouchableOpacity
-              onPress={() => remove(item.id)}
+              onPress={() => remove(item.checklistId)}
               accessibilityLabel="항목 삭제"
               accessibilityRole="button"
             >
               <Ionicons name="trash-outline" size={20} color={colors.primary[500]} />
             </TouchableOpacity>
-          ) : item.deadline ? (
-            <View style={styles.badge}>
-              <Text style={styles.badgeText}>{item.deadline}</Text>
-            </View>
           ) : null}
         </View>
       ))}
@@ -97,8 +123,14 @@ const styles = StyleSheet.create({
   list: {
     gap: 12,
   },
-  cardChecked: {
-    backgroundColor: colors.gray[100],
+  centered: {
+    paddingVertical: 60,
+    alignItems: 'center',
+  },
+  errorText: {
+    fontSize: 14,
+    fontFamily: fonts.medium,
+    color: colors.text.secondary,
   },
   card: {
     flexDirection: 'row',
@@ -112,6 +144,9 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.06,
     shadowRadius: 6,
     elevation: 3,
+  },
+  cardChecked: {
+    backgroundColor: colors.gray[100],
   },
   checkbox: {
     width: 20,
@@ -143,16 +178,5 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontFamily: fonts.regular,
     color: colors.text.secondary,
-  },
-  badge: {
-    backgroundColor: colors.secondary[600],
-    borderRadius: 20,
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-  },
-  badgeText: {
-    fontSize: 12,
-    fontFamily: fonts.semiBold,
-    color: colors.text.white,
   },
 });

--- a/src/components/scan/result/ChecklistTab.tsx
+++ b/src/components/scan/result/ChecklistTab.tsx
@@ -16,6 +16,10 @@ const ChecklistTab = ({ newsletterId }: Props) => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    setLoading(true);
+    setError(null);
+    setItems([]);
+
     if (!newsletterId) {
       setError('가정통신문 정보를 찾을 수 없어요.');
       setLoading(false);

--- a/src/components/scan/result/ChecklistTab.tsx
+++ b/src/components/scan/result/ChecklistTab.tsx
@@ -1,10 +1,7 @@
 import { useEffect, useState } from 'react';
 import { View, Text, TouchableOpacity, ActivityIndicator, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import {
-  getNewsletterChecklist,
-  NewsletterApiError,
-} from '../../../api/newsletter';
+import { getNewsletterChecklist, NewsletterApiError } from '../../../api/newsletter';
 import type { ChecklistItem } from '../../../api/newsletter';
 import colors from '../../../constants/colors';
 import fonts from '../../../constants/fonts';
@@ -13,7 +10,7 @@ interface Props {
   newsletterId?: number;
 }
 
-export default function ChecklistTab({ newsletterId }: Props) {
+const ChecklistTab = ({ newsletterId }: Props) => {
   const [items, setItems] = useState<ChecklistItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -22,7 +19,7 @@ export default function ChecklistTab({ newsletterId }: Props) {
     if (!newsletterId) {
       setError('가정통신문 정보를 찾을 수 없어요.');
       setLoading(false);
-      return;
+      return () => {};
     }
 
     let cancelled = false;
@@ -117,7 +114,9 @@ export default function ChecklistTab({ newsletterId }: Props) {
       ))}
     </View>
   );
-}
+};
+
+export default ChecklistTab;
 
 const styles = StyleSheet.create({
   list: {

--- a/src/components/scan/result/FullDocTab.tsx
+++ b/src/components/scan/result/FullDocTab.tsx
@@ -1,57 +1,116 @@
-import { useState } from 'react';
-import { View, Text, Image, StyleSheet, useWindowDimensions } from 'react-native';
+import { useEffect, useState } from 'react';
+import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
+import { getNewsletterTranslation, NewsletterTranslationResult, NewsletterApiError } from '../../../api/newsletter';
 import colors from '../../../constants/colors';
 import fonts from '../../../constants/fonts';
 
 interface Props {
-  photoUri: string;
+  newsletterId?: number;
 }
 
-export default function FullDocTab({ photoUri }: Props) {
-  const { width } = useWindowDimensions();
-  const containerWidth = width - 40;
-  const [imageHeight, setImageHeight] = useState(300);
+export default function FullDocTab({ newsletterId }: Props) {
+  const [data, setData] = useState<NewsletterTranslationResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!newsletterId) {
+      setError('가정통신문 정보를 찾을 수 없어요.');
+      setLoading(false);
+      return;
+    }
+
+    getNewsletterTranslation(newsletterId)
+      .then((result) => {
+        setData(result);
+        setLoading(false);
+      })
+      .catch((e) => {
+        if (e instanceof NewsletterApiError && e.code === 'NL4004') {
+          setError('아직 분석이 완료되지 않은 가정통신문이에요.');
+        } else if (e instanceof NewsletterApiError && e.code === 'NL4041') {
+          setError('가정통신문을 찾을 수 없어요.');
+        } else {
+          setError('문서를 불러오는 데 실패했어요.');
+        }
+        setLoading(false);
+      });
+  }, [newsletterId]);
+
+  if (loading) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" color={colors.primary[400]} />
+      </View>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.errorText}>{error ?? '문서를 불러오는 데 실패했어요.'}</Text>
+      </View>
+    );
+  }
+
+  const showTranslation = !!data.translatedText;
 
   return (
-    <View>
-      <Text style={styles.sectionLabel}>번역된 문서</Text>
-      <View style={styles.card}>
-        {photoUri ? (
-          <Image
-            source={{ uri: photoUri }}
-            style={[styles.image, { height: imageHeight }]}
-            resizeMode="contain"
-            onLoad={(e) => {
-              const { width: w, height: h } = e.nativeEvent.source;
-              setImageHeight((h / w) * containerWidth);
-            }}
-          />
-        ) : (
-          <View style={[styles.image, { height: imageHeight }]} />
-        )}
+    <View style={styles.container}>
+      {showTranslation && (
+        <View style={styles.section}>
+          <Text style={styles.sectionLabel}>번역된 문서</Text>
+          <View style={styles.card}>
+            <Text style={styles.bodyText}>{data.translatedText}</Text>
+          </View>
+        </View>
+      )}
+
+      <View style={styles.section}>
+        <Text style={styles.sectionLabel}>{showTranslation ? 'OCR 원문' : '원문'}</Text>
+        <View style={styles.card}>
+          <Text style={styles.bodyText}>{data.originalText}</Text>
+        </View>
       </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    gap: 20,
+  },
+  section: {
+    gap: 10,
+  },
+  centered: {
+    paddingVertical: 60,
+    alignItems: 'center',
+  },
+  errorText: {
+    fontSize: 14,
+    fontFamily: fonts.medium,
+    color: colors.text.secondary,
+  },
   sectionLabel: {
     fontSize: 13,
     fontFamily: fonts.medium,
     color: colors.text.secondary,
-    marginBottom: 10,
   },
   card: {
     borderRadius: 16,
-    backgroundColor: colors.gray[100],
-    overflow: 'hidden',
+    backgroundColor: colors.text.white,
+    padding: 16,
     shadowColor: colors.gray[300],
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.12,
     shadowRadius: 8,
     elevation: 4,
   },
-  image: {
-    width: '100%',
+  bodyText: {
+    fontSize: 14,
+    fontFamily: fonts.regular,
+    color: colors.text.primary,
+    lineHeight: 22,
   },
 });

--- a/src/components/scan/result/FullDocTab.tsx
+++ b/src/components/scan/result/FullDocTab.tsx
@@ -25,7 +25,7 @@ const FullDocTab = ({ newsletterId }: Props) => {
     if (!newsletterId) {
       setError('가정통신문 정보를 찾을 수 없어요.');
       setLoading(false);
-      return;
+      return () => {};
     }
 
     let cancelled = false;

--- a/src/components/scan/result/FullDocTab.tsx
+++ b/src/components/scan/result/FullDocTab.tsx
@@ -18,18 +18,26 @@ const FullDocTab = ({ newsletterId }: Props) => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    setLoading(true);
+    setError(null);
+    setData(null);
+
     if (!newsletterId) {
       setError('가정통신문 정보를 찾을 수 없어요.');
       setLoading(false);
       return;
     }
 
+    let cancelled = false;
+
     getNewsletterTranslation(newsletterId)
       .then((result) => {
+        if (cancelled) return;
         setData(result);
         setLoading(false);
       })
       .catch((e) => {
+        if (cancelled) return;
         if (e instanceof NewsletterApiError && e.code === 'NL4004') {
           setError('아직 분석이 완료되지 않은 가정통신문이에요.');
         } else if (e instanceof NewsletterApiError && e.code === 'NL4041') {
@@ -39,6 +47,10 @@ const FullDocTab = ({ newsletterId }: Props) => {
         }
         setLoading(false);
       });
+
+    return () => {
+      cancelled = true;
+    };
   }, [newsletterId]);
 
   if (loading) {

--- a/src/components/scan/result/FullDocTab.tsx
+++ b/src/components/scan/result/FullDocTab.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react';
 import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
-import { getNewsletterTranslation, NewsletterTranslationResult, NewsletterApiError } from '../../../api/newsletter';
+import {
+  getNewsletterTranslation,
+  NewsletterTranslationResult,
+  NewsletterApiError,
+} from '../../../api/newsletter';
 import colors from '../../../constants/colors';
 import fonts from '../../../constants/fonts';
 
@@ -8,7 +12,7 @@ interface Props {
   newsletterId?: number;
 }
 
-export default function FullDocTab({ newsletterId }: Props) {
+const FullDocTab = ({ newsletterId }: Props) => {
   const [data, setData] = useState<NewsletterTranslationResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -74,7 +78,9 @@ export default function FullDocTab({ newsletterId }: Props) {
       </View>
     </View>
   );
-}
+};
+
+export default FullDocTab;
 
 const styles = StyleSheet.create({
   container: {

--- a/src/components/scan/result/SaveBottomSheet.tsx
+++ b/src/components/scan/result/SaveBottomSheet.tsx
@@ -18,7 +18,12 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { PrimaryButton, SecondaryButton } from '../../common/Button';
 import styles from '../../../styles/scan/saveBottomSheet';
 import colors from '../../../constants/colors';
-import { getCalendarPreview, patchCalendarPreviewDates, postCalendarEvents, CalendarApiError } from '../../../api/calendar';
+import {
+  getCalendarPreview,
+  patchCalendarPreviewDates,
+  postCalendarEvents,
+  CalendarApiError,
+} from '../../../api/calendar';
 import type { CalendarPreviewItem } from '../../../api/calendar';
 
 interface Props {
@@ -39,9 +44,9 @@ const formatCorrectedDate = (y: string, m: string, d: string): string | null => 
   const yn = Number(y);
   const mn = Number(m);
   const dn = Number(d);
-  if (!y || !m || !d || isNaN(yn) || isNaN(mn) || isNaN(dn)) return null;
+  if (!y || !m || !d || Number.isNaN(yn) || Number.isNaN(mn) || Number.isNaN(dn)) return null;
   const date = new Date(yn, mn - 1, dn);
-  if (isNaN(date.getTime()) || date.getMonth() !== mn - 1) return null;
+  if (Number.isNaN(date.getTime()) || date.getMonth() !== mn - 1) return null;
   return `${String(yn).padStart(4, '0')}-${String(mn).padStart(2, '0')}-${String(dn).padStart(2, '0')}`;
 };
 
@@ -64,7 +69,7 @@ const mapPatchError = (e: unknown): string => {
 
 const getDisplayDate = (y: string, m: string, d: string) => {
   const date = new Date(Number(y), Number(m) - 1, Number(d));
-  const weekday = isNaN(date.getTime()) ? '' : `${WEEKDAYS[date.getDay()]}요일 · `;
+  const weekday = Number.isNaN(date.getTime()) ? '' : `${WEEKDAYS[date.getDay()]}요일 · `;
   return `${y}년 ${m}월 ${d}일 ${weekday}종일`;
 };
 
@@ -77,65 +82,63 @@ interface DateInputFieldsProps {
   onDayChange: (v: string) => void;
 }
 
-function DateInputFields({
+const DateInputFields = ({
   year,
   month,
   day,
   onYearChange,
   onMonthChange,
   onDayChange,
-}: DateInputFieldsProps) {
-  return (
-    <View style={styles.dateInputRow}>
-      <View style={styles.dateInputWrap}>
-        <TextInput
-          style={styles.dateInput}
-          value={year}
-          onChangeText={onYearChange}
-          keyboardType="number-pad"
-          maxLength={4}
-          accessibilityLabel="년도"
-        />
-        <Text style={styles.dateUnit}>년</Text>
-      </View>
-      <View style={styles.dateInputWrap}>
-        <TextInput
-          style={styles.dateInput}
-          value={month}
-          onChangeText={onMonthChange}
-          keyboardType="number-pad"
-          maxLength={2}
-          accessibilityLabel="월"
-        />
-        <Text style={styles.dateUnit}>월</Text>
-      </View>
-      <View style={styles.dateInputWrap}>
-        <TextInput
-          style={styles.dateInput}
-          value={day}
-          onChangeText={onDayChange}
-          keyboardType="number-pad"
-          maxLength={2}
-          accessibilityLabel="일"
-        />
-        <Text style={styles.dateUnit}>일</Text>
-      </View>
+}: DateInputFieldsProps) => (
+  <View style={styles.dateInputRow}>
+    <View style={styles.dateInputWrap}>
+      <TextInput
+        style={styles.dateInput}
+        value={year}
+        onChangeText={onYearChange}
+        keyboardType="number-pad"
+        maxLength={4}
+        accessibilityLabel="년도"
+      />
+      <Text style={styles.dateUnit}>년</Text>
     </View>
-  );
-}
+    <View style={styles.dateInputWrap}>
+      <TextInput
+        style={styles.dateInput}
+        value={month}
+        onChangeText={onMonthChange}
+        keyboardType="number-pad"
+        maxLength={2}
+        accessibilityLabel="월"
+      />
+      <Text style={styles.dateUnit}>월</Text>
+    </View>
+    <View style={styles.dateInputWrap}>
+      <TextInput
+        style={styles.dateInput}
+        value={day}
+        onChangeText={onDayChange}
+        keyboardType="number-pad"
+        maxLength={2}
+        accessibilityLabel="일"
+      />
+      <Text style={styles.dateUnit}>일</Text>
+    </View>
+  </View>
+);
 
 const STYLE_FULL_WIDTH = { width: '100%' } as const;
 const STYLE_FLEX_1 = { flex: 1 } as const;
 const STYLE_FLEX_2 = { flex: 2 } as const;
 
-export default function SaveBottomSheet({
+const SaveBottomSheet = ({
   visible,
   onClose,
   onConfirm,
   onDismiss,
   childName,
   newsletterId,
-}: Props) {
+}: Props) => {
   const insets = useSafeAreaInsets();
   const [show, setShow] = useState(false);
   const [step, setStep] = useState<'confirm' | 'success'>('confirm');
@@ -160,7 +163,7 @@ export default function SaveBottomSheet({
 
   // 미리보기 데이터 fetch
   useEffect(() => {
-    if (!visible || !newsletterId) return;
+    if (!visible || !newsletterId) return () => {};
     let cancelled = false;
 
     setPreviewLoading(true);
@@ -217,7 +220,11 @@ export default function SaveBottomSheet({
       keyboardOffset.setValue(0);
       Animated.parallel([
         Animated.timing(opacity, { toValue: 0, duration: 200, useNativeDriver: true }),
-        Animated.timing(translateY, { toValue: SHEET_HEIGHT, duration: 220, useNativeDriver: true }),
+        Animated.timing(translateY, {
+          toValue: SHEET_HEIGHT,
+          duration: 220,
+          useNativeDriver: true,
+        }),
       ]).start(({ finished }) => {
         if (finished) setShow(false);
       });
@@ -252,6 +259,46 @@ export default function SaveBottomSheet({
   }, [keyboardOffset]);
 
   const eventTitle = preview?.title ?? '';
+
+  const renderEventCardContent = () => {
+    if (previewLoading) return <ActivityIndicator size="small" color={colors.primary[400]} />;
+    if (previewError) return <Text style={localStyles.errorText}>{previewError}</Text>;
+    return (
+      <>
+        <View style={styles.eventHeader}>
+          <View style={styles.eventDot} />
+          <Text style={styles.eventTitle}>
+            {eventTitle} · {childName}
+          </Text>
+        </View>
+        {dateFound ? (
+          <View style={styles.eventDateRow}>
+            <Text style={styles.eventDate}>{displayDate}</Text>
+            <TouchableOpacity
+              style={styles.editBadge}
+              onPress={() => setIsEditing((v) => !v)}
+              accessibilityRole="button"
+              accessibilityLabel="일정 수정"
+            >
+              <Text style={styles.editBadgeText}>{isEditing ? '✏️ 수정 중' : '✏️ 수정'}</Text>
+            </TouchableOpacity>
+          </View>
+        ) : (
+          <>
+            <View style={styles.divider} />
+            <DateInputFields
+              year={year}
+              month={month}
+              day={day}
+              onYearChange={setYear}
+              onMonthChange={setMonth}
+              onDayChange={setDay}
+            />
+          </>
+        )}
+      </>
+    );
+  };
 
   const handleDateConfirm = async () => {
     const correctedDate = formatCorrectedDate(year, month, day);
@@ -380,47 +427,7 @@ export default function SaveBottomSheet({
                   </View>
                 )}
 
-                <View style={styles.eventCard}>
-                  {previewLoading ? (
-                    <ActivityIndicator size="small" color={colors.primary[400]} />
-                  ) : previewError ? (
-                    <Text style={localStyles.errorText}>{previewError}</Text>
-                  ) : (
-                    <>
-                      <View style={styles.eventHeader}>
-                        <View style={styles.eventDot} />
-                        <Text style={styles.eventTitle}>{eventTitle} · {childName}</Text>
-                      </View>
-                      {dateFound ? (
-                        <View style={styles.eventDateRow}>
-                          <Text style={styles.eventDate}>{displayDate}</Text>
-                          <TouchableOpacity
-                            style={styles.editBadge}
-                            onPress={() => setIsEditing((v) => !v)}
-                            accessibilityRole="button"
-                            accessibilityLabel="일정 수정"
-                          >
-                            <Text style={styles.editBadgeText}>
-                              {isEditing ? '✏️ 수정 중' : '✏️ 수정'}
-                            </Text>
-                          </TouchableOpacity>
-                        </View>
-                      ) : (
-                        <>
-                          <View style={styles.divider} />
-                          <DateInputFields
-                            year={year}
-                            month={month}
-                            day={day}
-                            onYearChange={setYear}
-                            onMonthChange={setMonth}
-                            onDayChange={setDay}
-                          />
-                        </>
-                      )}
-                    </>
-                  )}
-                </View>
+                <View style={styles.eventCard}>{renderEventCardContent()}</View>
 
                 {dateFound && isEditing && (
                   <View style={styles.dateEditorCard}>
@@ -453,7 +460,7 @@ export default function SaveBottomSheet({
                 <View style={styles.buttons}>
                   <SecondaryButton label="아니요" onPress={onClose} style={STYLE_FLEX_1} />
                   <PrimaryButton
-                    label={(datePatching || registering) ? '저장 중...' : '✓ 네, 등록할게요'}
+                    label={datePatching || registering ? '저장 중...' : '✓ 네, 등록할게요'}
                     onPress={handleRegisterConfirm}
                     disabled={datePatching || registering}
                     style={STYLE_FLEX_2}
@@ -466,7 +473,9 @@ export default function SaveBottomSheet({
       </View>
     </Modal>
   );
-}
+};
+
+export default SaveBottomSheet;
 
 const localStyles = StyleSheet.create({
   errorText: {

--- a/src/components/scan/result/SaveBottomSheet.tsx
+++ b/src/components/scan/result/SaveBottomSheet.tsx
@@ -322,14 +322,21 @@ const SaveBottomSheet = ({
     setIsEditing(false);
   };
 
+  const canRegister = !!newsletterId && !!preview && !previewLoading && !previewError;
+
   const handleRegisterConfirm = async () => {
+    if (!canRegister) {
+      Alert.alert('등록 실패', '일정 미리보기 정보를 먼저 불러와주세요.');
+      return;
+    }
+
     const startAt = formatCorrectedDate(year, month, day);
     if (!startAt) {
       Alert.alert('오류', '올바른 날짜를 입력해주세요.');
       return;
     }
 
-    if (!dateFound && newsletterId && preview?.tempEventId) {
+    if (!dateFound && preview.tempEventId) {
       setDatePatching(true);
       try {
         await patchCalendarPreviewDates(newsletterId, [
@@ -343,21 +350,16 @@ const SaveBottomSheet = ({
       setDatePatching(false);
     }
 
-    if (newsletterId && preview) {
-      setRegistering(true);
-      try {
-        await postCalendarEvents(newsletterId, [
-          { tempEventId: preview.tempEventId, title: preview.title, startAt, endAt: null },
-        ]);
-      } catch (e) {
-        Alert.alert('등록 실패', mapRegisterError(e));
-        setRegistering(false);
-        return;
-      }
-      setRegistering(false);
+    setRegistering(true);
+    try {
+      await postCalendarEvents(newsletterId, [
+        { tempEventId: preview.tempEventId, title: preview.title, startAt, endAt: null },
+      ]);
+      setStep('success');
+    } catch (e) {
+      Alert.alert('등록 실패', mapRegisterError(e));
     }
-
-    setStep('success');
+    setRegistering(false);
   };
 
   return (
@@ -462,7 +464,7 @@ const SaveBottomSheet = ({
                   <PrimaryButton
                     label={datePatching || registering ? '저장 중...' : '✓ 네, 등록할게요'}
                     onPress={handleRegisterConfirm}
-                    disabled={datePatching || registering}
+                    disabled={datePatching || registering || !canRegister}
                     style={STYLE_FLEX_2}
                   />
                 </View>

--- a/src/components/scan/result/SaveBottomSheet.tsx
+++ b/src/components/scan/result/SaveBottomSheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -10,12 +10,16 @@ import {
   StyleSheet,
   Keyboard,
   Platform,
+  ActivityIndicator,
+  Alert,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { PrimaryButton, SecondaryButton } from '../../common/Button';
 import styles from '../../../styles/scan/saveBottomSheet';
 import colors from '../../../constants/colors';
+import { getCalendarPreview, patchCalendarPreviewDates, postCalendarEvents, CalendarApiError } from '../../../api/calendar';
+import type { CalendarPreviewItem } from '../../../api/calendar';
 
 interface Props {
   visible: boolean;
@@ -23,11 +27,46 @@ interface Props {
   onConfirm: () => void;
   onDismiss: () => void;
   childName: string;
-  dateFound?: boolean;
+  newsletterId?: number;
 }
 
 const SHEET_HEIGHT = 560;
 const returnTrue = () => true;
+
+const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'] as const;
+
+const formatCorrectedDate = (y: string, m: string, d: string): string | null => {
+  const yn = Number(y);
+  const mn = Number(m);
+  const dn = Number(d);
+  if (!y || !m || !d || isNaN(yn) || isNaN(mn) || isNaN(dn)) return null;
+  const date = new Date(yn, mn - 1, dn);
+  if (isNaN(date.getTime()) || date.getMonth() !== mn - 1) return null;
+  return `${String(yn).padStart(4, '0')}-${String(mn).padStart(2, '0')}-${String(dn).padStart(2, '0')}`;
+};
+
+const mapRegisterError = (e: unknown): string => {
+  if (e instanceof CalendarApiError) {
+    if (e.code === 'COMMON4001') return '입력값이 올바르지 않아요.';
+    if (e.code === 'NL4041') return '가정통신문을 찾을 수 없어요.';
+  }
+  return '일정 등록에 실패했어요.';
+};
+
+const mapPatchError = (e: unknown): string => {
+  if (e instanceof CalendarApiError) {
+    if (e.code === 'COMMON4001') return '날짜 형식이 올바르지 않아요.';
+    if (e.code === 'NL4041') return '가정통신문을 찾을 수 없어요.';
+    if (e.code === 'CAL4042') return '미리보기 데이터가 만료됐어요. 다시 시도해주세요.';
+  }
+  return '날짜 저장에 실패했어요.';
+};
+
+const getDisplayDate = (y: string, m: string, d: string) => {
+  const date = new Date(Number(y), Number(m) - 1, Number(d));
+  const weekday = isNaN(date.getTime()) ? '' : `${WEEKDAYS[date.getDay()]}요일 · `;
+  return `${y}년 ${m}월 ${d}일 ${weekday}종일`;
+};
 
 interface DateInputFieldsProps {
   year: string;
@@ -85,12 +124,6 @@ function DateInputFields({
   );
 }
 
-// TODO: 실제 문서에서 추출한 일정 데이터로 교체
-const MOCK_EVENT = {
-  title: '봄 현장학습',
-  reminders: ['동의서 마감 알림 - 3월 22일', '당일 준비 알림 - 3월 26일'],
-};
-
 const STYLE_FULL_WIDTH = { width: '100%' } as const;
 const STYLE_FLEX_1 = { flex: 1 } as const;
 const STYLE_FLEX_2 = { flex: 2 } as const;
@@ -101,24 +134,72 @@ export default function SaveBottomSheet({
   onConfirm,
   onDismiss,
   childName,
-  dateFound = true,
+  newsletterId,
 }: Props) {
   const insets = useSafeAreaInsets();
   const [show, setShow] = useState(false);
   const [step, setStep] = useState<'confirm' | 'success'>('confirm');
   const [isEditing, setIsEditing] = useState(false);
-  // TODO: 추출된 날짜로 초기값 설정
-  const [year, setYear] = useState('2026');
-  const [month, setMonth] = useState('3');
-  const [day, setDay] = useState('26');
+  const [year, setYear] = useState('');
+  const [month, setMonth] = useState('');
+  const [day, setDay] = useState('');
+
+  const [preview, setPreview] = useState<CalendarPreviewItem | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [datePatching, setDatePatching] = useState(false);
+  const [registering, setRegistering] = useState(false);
 
   const opacity = useRef(new Animated.Value(0)).current;
   const translateY = useRef(new Animated.Value(SHEET_HEIGHT)).current;
   const keyboardOffset = useRef(new Animated.Value(0)).current;
   const combinedY = useRef(Animated.add(translateY, keyboardOffset)).current;
 
-  const displayDate = `${year}년 ${month}월 ${day}일 목요일 · 종일`; // TODO: 추출된 날짜 및 실제 요일 계산으로 교체
+  const dateFound = preview?.isDateExtracted ?? true;
+  const displayDate = getDisplayDate(year, month, day);
 
+  // 미리보기 데이터 fetch
+  useEffect(() => {
+    if (!visible || !newsletterId) return;
+    let cancelled = false;
+
+    setPreviewLoading(true);
+    setPreviewError(null);
+
+    getCalendarPreview(newsletterId)
+      .then((items) => {
+        if (cancelled) return;
+        const first = items[0] ?? null;
+        setPreview(first);
+        if (first?.extractedDate) {
+          const [y, m, d] = first.extractedDate.split('-');
+          setYear(y);
+          setMonth(String(Number(m)));
+          setDay(String(Number(d)));
+        } else {
+          setYear('');
+          setMonth('');
+          setDay('');
+        }
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        if (e instanceof CalendarApiError && e.code === 'CAL4042') {
+          setPreviewError('AI 분석 중이거나 미리보기 데이터가 만료됐어요.');
+        } else {
+          setPreviewError('일정 정보를 불러오는 데 실패했어요.');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setPreviewLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [visible, newsletterId]);
+
+  // 시트 애니메이션
   useEffect(() => {
     if (visible) {
       if (show) return;
@@ -136,17 +217,14 @@ export default function SaveBottomSheet({
       keyboardOffset.setValue(0);
       Animated.parallel([
         Animated.timing(opacity, { toValue: 0, duration: 200, useNativeDriver: true }),
-        Animated.timing(translateY, {
-          toValue: SHEET_HEIGHT,
-          duration: 220,
-          useNativeDriver: true,
-        }),
+        Animated.timing(translateY, { toValue: SHEET_HEIGHT, duration: 220, useNativeDriver: true }),
       ]).start(({ finished }) => {
         if (finished) setShow(false);
       });
     }
   }, [visible, show, opacity, translateY, keyboardOffset]);
 
+  // 키보드 오프셋
   useEffect(() => {
     const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
     const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
@@ -172,6 +250,68 @@ export default function SaveBottomSheet({
       onHide.remove();
     };
   }, [keyboardOffset]);
+
+  const eventTitle = preview?.title ?? '';
+
+  const handleDateConfirm = async () => {
+    const correctedDate = formatCorrectedDate(year, month, day);
+    if (!correctedDate) {
+      Alert.alert('오류', '올바른 날짜를 입력해주세요.');
+      return;
+    }
+    if (newsletterId && preview?.tempEventId) {
+      setDatePatching(true);
+      try {
+        await patchCalendarPreviewDates(newsletterId, [
+          { tempEventId: preview.tempEventId, correctedDate },
+        ]);
+      } catch (e) {
+        Alert.alert('날짜 저장 실패', mapPatchError(e));
+        setDatePatching(false);
+        return;
+      }
+      setDatePatching(false);
+    }
+    setIsEditing(false);
+  };
+
+  const handleRegisterConfirm = async () => {
+    const startAt = formatCorrectedDate(year, month, day);
+    if (!startAt) {
+      Alert.alert('오류', '올바른 날짜를 입력해주세요.');
+      return;
+    }
+
+    if (!dateFound && newsletterId && preview?.tempEventId) {
+      setDatePatching(true);
+      try {
+        await patchCalendarPreviewDates(newsletterId, [
+          { tempEventId: preview.tempEventId, correctedDate: startAt },
+        ]);
+      } catch (e) {
+        Alert.alert('날짜 저장 실패', mapPatchError(e));
+        setDatePatching(false);
+        return;
+      }
+      setDatePatching(false);
+    }
+
+    if (newsletterId && preview) {
+      setRegistering(true);
+      try {
+        await postCalendarEvents(newsletterId, [
+          { tempEventId: preview.tempEventId, title: preview.title, startAt, endAt: null },
+        ]);
+      } catch (e) {
+        Alert.alert('등록 실패', mapRegisterError(e));
+        setRegistering(false);
+        return;
+      }
+      setRegistering(false);
+    }
+
+    setStep('success');
+  };
 
   return (
     <Modal visible={show} transparent animationType="none" onRequestClose={onClose}>
@@ -207,19 +347,10 @@ export default function SaveBottomSheet({
                     <View style={styles.eventDot} />
                     <View style={styles.successEventInfo}>
                       <Text style={styles.eventTitle}>
-                        {MOCK_EVENT.title} · {childName}
+                        {eventTitle} · {childName}
                       </Text>
                       <Text style={styles.eventDate}>{displayDate}</Text>
                     </View>
-                  </View>
-                  <View style={styles.divider} />
-                  <View style={styles.reminderList}>
-                    {MOCK_EVENT.reminders.map((r) => (
-                      <View key={r} style={styles.reminderRow}>
-                        <Text style={styles.reminderBullet}>•</Text>
-                        <Text style={styles.reminderText}>{r}</Text>
-                      </View>
-                    ))}
                   </View>
                 </View>
                 <PrimaryButton
@@ -239,6 +370,7 @@ export default function SaveBottomSheet({
                       : '날짜를 직접 입력해주세요.'}
                   </Text>
                 </View>
+
                 {!dateFound && (
                   <View style={styles.warningCard}>
                     <Ionicons name="warning" size={16} color={colors.text.primary} />
@@ -247,52 +379,49 @@ export default function SaveBottomSheet({
                     </Text>
                   </View>
                 )}
+
                 <View style={styles.eventCard}>
-                  <View style={styles.eventHeader}>
-                    <View style={styles.eventDot} />
-                    <Text style={styles.eventTitle}>
-                      {MOCK_EVENT.title} · {childName}
-                    </Text>
-                  </View>
-                  {dateFound ? (
-                    <>
-                      <View style={styles.eventDateRow}>
-                        <Text style={styles.eventDate}>{displayDate}</Text>
-                        <TouchableOpacity
-                          style={styles.editBadge}
-                          onPress={() => setIsEditing((v) => !v)}
-                          accessibilityRole="button"
-                          accessibilityLabel="일정 수정"
-                        >
-                          <Text style={styles.editBadgeText}>
-                            {isEditing ? '✏️ 수정 중' : '✏️ 수정'}
-                          </Text>
-                        </TouchableOpacity>
-                      </View>
-                      <View style={styles.divider} />
-                      <View style={styles.reminderList}>
-                        {MOCK_EVENT.reminders.map((r) => (
-                          <View key={r} style={styles.reminderRow}>
-                            <Text style={styles.reminderBullet}>•</Text>
-                            <Text style={styles.reminderText}>{r}</Text>
-                          </View>
-                        ))}
-                      </View>
-                    </>
+                  {previewLoading ? (
+                    <ActivityIndicator size="small" color={colors.primary[400]} />
+                  ) : previewError ? (
+                    <Text style={localStyles.errorText}>{previewError}</Text>
                   ) : (
                     <>
-                      <View style={styles.divider} />
-                      <DateInputFields
-                        year={year}
-                        month={month}
-                        day={day}
-                        onYearChange={setYear}
-                        onMonthChange={setMonth}
-                        onDayChange={setDay}
-                      />
+                      <View style={styles.eventHeader}>
+                        <View style={styles.eventDot} />
+                        <Text style={styles.eventTitle}>{eventTitle} · {childName}</Text>
+                      </View>
+                      {dateFound ? (
+                        <View style={styles.eventDateRow}>
+                          <Text style={styles.eventDate}>{displayDate}</Text>
+                          <TouchableOpacity
+                            style={styles.editBadge}
+                            onPress={() => setIsEditing((v) => !v)}
+                            accessibilityRole="button"
+                            accessibilityLabel="일정 수정"
+                          >
+                            <Text style={styles.editBadgeText}>
+                              {isEditing ? '✏️ 수정 중' : '✏️ 수정'}
+                            </Text>
+                          </TouchableOpacity>
+                        </View>
+                      ) : (
+                        <>
+                          <View style={styles.divider} />
+                          <DateInputFields
+                            year={year}
+                            month={month}
+                            day={day}
+                            onYearChange={setYear}
+                            onMonthChange={setMonth}
+                            onDayChange={setDay}
+                          />
+                        </>
+                      )}
                     </>
                   )}
                 </View>
+
                 {dateFound && isEditing && (
                   <View style={styles.dateEditorCard}>
                     <Text style={styles.dateEditorLabel}>날짜 변경</Text>
@@ -306,20 +435,27 @@ export default function SaveBottomSheet({
                     />
                     <TouchableOpacity
                       style={styles.dateConfirmBtn}
-                      onPress={() => setIsEditing(false)}
+                      onPress={handleDateConfirm}
+                      disabled={datePatching}
                       activeOpacity={0.8}
                       accessibilityRole="button"
                       accessibilityLabel="날짜 확인"
                     >
-                      <Text style={styles.dateConfirmBtnText}>확인</Text>
+                      {datePatching ? (
+                        <ActivityIndicator size="small" color={colors.text.white} />
+                      ) : (
+                        <Text style={styles.dateConfirmBtnText}>확인</Text>
+                      )}
                     </TouchableOpacity>
                   </View>
                 )}
+
                 <View style={styles.buttons}>
                   <SecondaryButton label="아니요" onPress={onClose} style={STYLE_FLEX_1} />
                   <PrimaryButton
-                    label="✓ 네, 등록할게요"
-                    onPress={() => setStep('success')}
+                    label={(datePatching || registering) ? '저장 중...' : '✓ 네, 등록할게요'}
+                    onPress={handleRegisterConfirm}
+                    disabled={datePatching || registering}
                     style={STYLE_FLEX_2}
                   />
                 </View>
@@ -331,3 +467,12 @@ export default function SaveBottomSheet({
     </Modal>
   );
 }
+
+const localStyles = StyleSheet.create({
+  errorText: {
+    fontSize: 13,
+    color: colors.text.secondary,
+    textAlign: 'center',
+    paddingVertical: 8,
+  },
+});

--- a/src/components/scan/result/SummaryCard.tsx
+++ b/src/components/scan/result/SummaryCard.tsx
@@ -11,19 +11,19 @@ interface Props {
   children: ReactNode;
 }
 
-export default function SummaryCard({ icon, iconBg, title, children }: Props) {
-  return (
-    <View style={styles.card}>
-      <View style={styles.header}>
-        <View style={[styles.iconWrap, { backgroundColor: iconBg }]}>
-          <Ionicons name={icon} size={20} color={colors.text.white} />
-        </View>
-        <Text style={styles.title}>{title}</Text>
+const SummaryCard = ({ icon, iconBg, title, children }: Props) => (
+  <View style={styles.card}>
+    <View style={styles.header}>
+      <View style={[styles.iconWrap, { backgroundColor: iconBg }]}>
+        <Ionicons name={icon} size={20} color={colors.text.white} />
       </View>
-      {children}
+      <Text style={styles.title}>{title}</Text>
     </View>
-  );
-}
+    {children}
+  </View>
+);
+
+export default SummaryCard;
 
 const styles = StyleSheet.create({
   card: {

--- a/src/components/scan/result/SummaryCard.tsx
+++ b/src/components/scan/result/SummaryCard.tsx
@@ -30,7 +30,7 @@ const styles = StyleSheet.create({
     backgroundColor: colors.text.white,
     borderRadius: 20,
     padding: 20,
-    gap: 14,
+    gap: 8,
     shadowColor: colors.primary[200],
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.06,


### PR DESCRIPTION
## 📌 작업 내용

- expo-document-picker 패키지 추가
- 가정통신문 API 모듈 추가 (src/api/newsletter.ts) — 업로드, 번역, 체크리스트, 요약, 상세 조회, 분석 상태 폴링
- getMyChildren API 추가 (src/api/calendar.ts)
- 스캔 자녀 선택 화면 실제 API 연동 및 PDF 업로드 지원
- 카메라 화면 childId 전달 및 촬영 이미지 압축 적용
- 미리보기 화면 PDF 미리보기 지원
- 스캔 로딩 화면 업로드 → 분석 상태 폴링 연동
- 스캔 결과 화면 API 연동 — 전체 문서 / 체크리스트 / AI 요약 탭 (상세 조회, 번역, 체크리스트, 요약)
- 캘린더 미리보기 조회 · 날짜 수정 · 일정 등록 API 추가 (src/api/calendar.ts)
- SaveBottomSheet 캘린더 API 연동 — 미리보기 로딩/에러 처리, 날짜 수정 PATCH, 일정 등록 POST

## 📷 스크린 샷

| 화면 1 | 화면 2 | 화면 3 |
|---|---|---|
| <img width="220" alt="Screenshot_1779214489" src="https://github.com/user-attachments/assets/6adade91-6e8a-4e1a-a387-8f5c3ccab20c" /> | <img width="220" alt="Screenshot_1779214093" src="https://github.com/user-attachments/assets/acb40657-dd60-4175-83f0-4a4da926e840" /> | <img width="220" alt="Screenshot_1779214220" src="https://github.com/user-attachments/assets/9f66d7ec-7c47-42e0-9813-2dc8a20cffe9" /> |
| <img width="220" alt="Screenshot_1779214221" src="https://github.com/user-attachments/assets/5505c883-063e-40cb-b2e3-5175d87354d9" /> | <img width="220" alt="Screenshot_1779214223" src="https://github.com/user-attachments/assets/e897e854-845b-427e-a225-c254c06ca268" /> | <img width="220" alt="Screenshot_1779214229" src="https://github.com/user-attachments/assets/eb9db6f3-dbb1-45c0-84e3-758f3398d537" /> |

## ⚠️ 참고 사항

- 캘린더 미리보기(GET /api/v1/newsletters/{id}/calendar/preview) 호출 시 CAL4042 에러 발생 — 서버에서 미리보기 데이터가 생성되지 않는 것으로 확인, 백엔드 수정 필요

## 🔗 관련 이슈

Closes #37 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * PDF 문서 업로드 및 미리보기(파일명/아이콘 표시) 지원
  * AI 요약·체크리스트·원문 번역 로드 및 탭별 표시
  * 캘린더 미리보기, 날짜 수정 및 일정 등록 흐름 추가
  * 자녀 선택을 API로 동적 로드

* **개선사항**
  * 촬영·갤러리 이미지 자동 리사이즈·JPEG 압축 적용(성능/전송 최적화)
  * 업로드 상태 폴링 기반 진행률 및 상태 메시지 표시
  * 라우트에 자녀 식별자(childId)/newsletterId 전달 보강

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GACHI-Project/GACHI-FE/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->