### PR TITLE
✨ [Feature] 캘린더 미리보기 더미 데이터 주입 API 연동 (임시) (#41)

### DIFF
--- a/app/scan/result.tsx
+++ b/app/scan/result.tsx
@@ -162,6 +162,7 @@ const ScanResultScreen = () => {
         onDismiss={() => router.replace('/(tabs)')}
         childName={displayChildName}
         newsletterId={newsletterId}
+        newsletterTitle={displayTitle}
       />
     </View>
   );

--- a/src/api/calendar.ts
+++ b/src/api/calendar.ts
@@ -143,7 +143,7 @@ export const fetchWeeklyEvents = async (
 };
 
 export interface CalendarPreviewItem {
-  tempEventId: number;
+  tempEventId: string;
   title: string;
   extractedDate: string | null;
   isDateExtracted: boolean;
@@ -152,18 +152,18 @@ export interface CalendarPreviewItem {
 export const getCalendarPreview = async (newsletterId: number): Promise<CalendarPreviewItem[]> => {
   try {
     const headers = await getAuthHeader();
-    const response = await apiClient.get<{ result: { items: CalendarPreviewItem[] } }>(
+    const response = await apiClient.get<{ result: { events: CalendarPreviewItem[] } }>(
       `/api/v1/newsletters/${newsletterId}/calendar/preview`,
       { headers }
     );
-    return response.data.result.items;
+    return response.data.result?.events ?? [];
   } catch (error) {
     throw wrapError(error);
   }
 };
 
 export interface CalendarDatePatchEvent {
-  tempEventId: number;
+  tempEventId: string;
   correctedDate: string;
 }
 
@@ -184,7 +184,7 @@ export const patchCalendarPreviewDates = async (
 };
 
 export interface CalendarPostEvent {
-  tempEventId: number;
+  tempEventId: string;
   title: string;
   startAt: string;
   endAt: string | null;
@@ -202,6 +202,28 @@ export const postCalendarEvents = async (
       { headers }
     );
     return response.data.result;
+  } catch (error) {
+    throw wrapError(error);
+  }
+};
+
+export interface CalendarPreviewDummyEvent {
+  title: string;
+  extractedDate: string | null;
+  checklistIds: number[] | null;
+}
+
+export const injectCalendarPreviewDummy = async (
+  newsletterId: number,
+  events: CalendarPreviewDummyEvent[]
+): Promise<void> => {
+  try {
+    const headers = await getAuthHeader();
+    await apiClient.post(
+      `/api/v1/newsletters/${newsletterId}/calendar/preview/mock`,
+      { events },
+      { headers }
+    );
   } catch (error) {
     throw wrapError(error);
   }

--- a/src/components/scan/result/SaveBottomSheet.tsx
+++ b/src/components/scan/result/SaveBottomSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -9,7 +9,9 @@ import {
   Animated,
   StyleSheet,
   Keyboard,
+  ScrollView,
   Platform,
+  Dimensions,
   ActivityIndicator,
   Alert,
 } from 'react-native';
@@ -22,11 +24,12 @@ import styles from '../../../styles/scan/saveBottomSheet';
 import colors from '../../../constants/colors';
 import {
   getCalendarPreview,
-  patchCalendarPreviewDates,
   postCalendarEvents,
+  injectCalendarPreviewDummy,
   CalendarApiError,
 } from '../../../api/calendar';
 import type { CalendarPreviewItem } from '../../../api/calendar';
+import { getNewsletterTranslation } from '../../../api/newsletter';
 
 interface Props {
   visible: boolean;
@@ -35,10 +38,52 @@ interface Props {
   onDismiss: () => void;
   childName: string;
   newsletterId?: number;
+  newsletterTitle?: string;
+}
+
+type EventState = {
+  year: string;
+  month: string;
+  day: string;
+  isEditing: boolean;
+};
+
+interface DateInputFieldsProps {
+  year: string;
+  month: string;
+  day: string;
+  onYearChange: (v: string) => void;
+  onMonthChange: (v: string) => void;
+  onDayChange: (v: string) => void;
+}
+
+interface EventCardProps {
+  item: CalendarPreviewItem;
+  es: EventState;
+  childName: string;
+  onUpdate: (id: string, patch: Partial<EventState>) => void;
+  onDateConfirm: (id: string) => void;
+  getDisplayDate: (y: string, m: string, d: string) => string;
 }
 
 const SHEET_HEIGHT = 560;
+const WINDOW_HEIGHT = Dimensions.get('window').height;
 const returnTrue = () => true;
+const STYLE_FULL_WIDTH = { width: '100%' } as const;
+const STYLE_FLEX_1 = { flex: 1 } as const;
+const STYLE_FLEX_2 = { flex: 2 } as const;
+
+const localStyles = StyleSheet.create({
+  scrollArea: { width: '100%', flexShrink: 1 },
+  scrollContent: { gap: 12 },
+  loadingIndicator: { marginVertical: 16 },
+  errorText: {
+    fontSize: 13,
+    color: colors.text.secondary,
+    textAlign: 'center',
+    paddingVertical: 8,
+  },
+});
 
 const formatCorrectedDate = (y: string, m: string, d: string): string | null => {
   const yn = Number(y);
@@ -58,25 +103,7 @@ const mapRegisterError = (e: unknown): string => {
   return i18n.t('scan.result.saveBottomSheet.error.registerDefault');
 };
 
-const mapPatchError = (e: unknown): string => {
-  if (e instanceof CalendarApiError) {
-    if (e.code === 'COMMON4001') return i18n.t('scan.result.saveBottomSheet.error.dateFormat');
-    if (e.code === 'NL4041') return i18n.t('scan.result.saveBottomSheet.error.newsletterNotFound');
-    if (e.code === 'CAL4042') return i18n.t('scan.result.saveBottomSheet.error.previewExpired');
-  }
-  return i18n.t('scan.result.saveBottomSheet.error.dateSaveDefault');
-};
-
-interface DateInputFieldsProps {
-  year: string;
-  month: string;
-  day: string;
-  onYearChange: (v: string) => void;
-  onMonthChange: (v: string) => void;
-  onDayChange: (v: string) => void;
-}
-
-const DateInputFields = ({
+const DateInputFields = memo(({
   year,
   month,
   day,
@@ -122,11 +149,104 @@ const DateInputFields = ({
       </View>
     </View>
   );
-};
+});
 
-const STYLE_FULL_WIDTH = { width: '100%' } as const;
-const STYLE_FLEX_1 = { flex: 1 } as const;
-const STYLE_FLEX_2 = { flex: 2 } as const;
+const EventCard = memo(({
+  item,
+  es,
+  childName,
+  onUpdate,
+  onDateConfirm,
+  getDisplayDate,
+}: EventCardProps) => {
+  const { t } = useTranslation();
+  const displayDate = getDisplayDate(es.year, es.month, es.day);
+
+  const handleEditToggle = useCallback(
+    () => onUpdate(item.tempEventId, { isEditing: !es.isEditing }),
+    [onUpdate, item.tempEventId, es.isEditing]
+  );
+  const handleConfirm = useCallback(
+    () => onDateConfirm(item.tempEventId),
+    [onDateConfirm, item.tempEventId]
+  );
+  const handleYearChange = useCallback(
+    (v: string) => onUpdate(item.tempEventId, { year: v }),
+    [onUpdate, item.tempEventId]
+  );
+  const handleMonthChange = useCallback(
+    (v: string) => onUpdate(item.tempEventId, { month: v }),
+    [onUpdate, item.tempEventId]
+  );
+  const handleDayChange = useCallback(
+    (v: string) => onUpdate(item.tempEventId, { day: v }),
+    [onUpdate, item.tempEventId]
+  );
+
+  return (
+    <View style={styles.eventCard}>
+      <View style={styles.eventHeader}>
+        <View style={styles.eventDot} />
+        <Text style={styles.eventTitle}>{item.title} · {childName}</Text>
+      </View>
+      {item.isDateExtracted ? (
+        <View style={styles.eventDateRow}>
+          <Text style={styles.eventDate}>{displayDate}</Text>
+          <TouchableOpacity
+            style={styles.editBadge}
+            onPress={handleEditToggle}
+            accessibilityRole="button"
+            accessibilityLabel={t('scan.result.saveBottomSheet.accessibilityEdit')}
+          >
+            <Text style={styles.editBadgeText}>
+              {es.isEditing
+                ? t('scan.result.saveBottomSheet.isEditing')
+                : t('scan.result.saveBottomSheet.edit')}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <>
+          <View style={styles.divider} />
+          <DateInputFields
+            year={es.year}
+            month={es.month}
+            day={es.day}
+            onYearChange={handleYearChange}
+            onMonthChange={handleMonthChange}
+            onDayChange={handleDayChange}
+          />
+        </>
+      )}
+      {item.isDateExtracted && es.isEditing && (
+        <View style={styles.dateEditorCard}>
+          <Text style={styles.dateEditorLabel}>
+            {t('scan.result.saveBottomSheet.dateEditor')}
+          </Text>
+          <DateInputFields
+            year={es.year}
+            month={es.month}
+            day={es.day}
+            onYearChange={handleYearChange}
+            onMonthChange={handleMonthChange}
+            onDayChange={handleDayChange}
+          />
+          <TouchableOpacity
+            style={styles.dateConfirmBtn}
+            onPress={handleConfirm}
+            activeOpacity={0.8}
+            accessibilityRole="button"
+            accessibilityLabel={t('scan.result.saveBottomSheet.accessibilityDateConfirm')}
+          >
+            <Text style={styles.dateConfirmBtnText}>
+              {t('scan.result.saveBottomSheet.dateConfirm')}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      )}
+    </View>
+  );
+});
 
 const SaveBottomSheet = ({
   visible,
@@ -135,71 +255,122 @@ const SaveBottomSheet = ({
   onDismiss,
   childName,
   newsletterId,
+  newsletterTitle,
 }: Props) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const insets = useSafeAreaInsets();
+
   const [show, setShow] = useState(false);
   const [step, setStep] = useState<'confirm' | 'success'>('confirm');
-  const [isEditing, setIsEditing] = useState(false);
-  const [year, setYear] = useState('');
-  const [month, setMonth] = useState('');
-  const [day, setDay] = useState('');
-
-  const [preview, setPreview] = useState<CalendarPreviewItem | null>(null);
+  const [previews, setPreviews] = useState<CalendarPreviewItem[]>([]);
+  const [eventStates, setEventStates] = useState<Record<string, EventState>>({});
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
-  const [datePatching, setDatePatching] = useState(false);
   const [registering, setRegistering] = useState(false);
+
+  const updateEventState = useCallback(
+    (id: string, patch: Partial<EventState>) =>
+      setEventStates((prev) => ({ ...prev, [id]: { ...prev[id], ...patch } })),
+    []
+  );
+
+  const newsletterTitleRef = useRef(newsletterTitle);
+  useEffect(() => { newsletterTitleRef.current = newsletterTitle; }, [newsletterTitle]);
 
   const opacity = useRef(new Animated.Value(0)).current;
   const translateY = useRef(new Animated.Value(SHEET_HEIGHT)).current;
   const keyboardOffset = useRef(new Animated.Value(0)).current;
   const combinedY = useRef(Animated.add(translateY, keyboardOffset)).current;
 
-  const dateFound = preview?.isDateExtracted ?? true;
-  const weekdays = t('scan.result.saveBottomSheet.weekdays', { returnObjects: true }) as string[];
-  const getDisplayDate = (y: string, m: string, d: string) => {
-    const date = new Date(Number(y), Number(m) - 1, Number(d));
-    const weekday = Number.isNaN(date.getTime()) ? '' : `${weekdays[date.getDay()]} · `;
-    return `${y}${t('scan.result.saveBottomSheet.year')} ${m}${t('scan.result.saveBottomSheet.month')} ${d}${t('scan.result.saveBottomSheet.day')} ${weekday}${t('scan.result.saveBottomSheet.fullDay')}`;
-  };
-  const displayDate = getDisplayDate(year, month, day);
+  const animatedTransformStyle = useRef({ transform: [{ translateY: combinedY }] }).current;
 
-  // 미리보기 데이터 fetch
+  const sheetStyle = useMemo(
+    () => [styles.sheet, { paddingBottom: insets.bottom + 20, maxHeight: WINDOW_HEIGHT * 0.75 }],
+    [insets.bottom]
+  );
+
+  const hasAnyMissingDate = previews.some((p) => !p.isDateExtracted);
+
+  const getDisplayDate = useCallback(
+    (y: string, m: string, d: string) => {
+      if (!y || !m || !d) return '';
+      const date = new Date(Number(y), Number(m) - 1, Number(d));
+      if (Number.isNaN(date.getTime())) return '';
+      const dateStr = new Intl.DateTimeFormat(i18n.language, {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        weekday: 'long',
+      }).format(date);
+      return `${dateStr} · ${t('scan.result.saveBottomSheet.fullDay')}`;
+    },
+    [i18n.language, t]
+  );
+
+  // 미리보기 데이터 fetch (임시: AI 파이프라인 연결 전 더미 주입 후 preview 조회)
   useEffect(() => {
     if (!visible || !newsletterId) return () => {};
     let cancelled = false;
 
+    setPreviews([]);
+    setEventStates({});
     setPreviewLoading(true);
     setPreviewError(null);
 
-    getCalendarPreview(newsletterId)
-      .then((items) => {
+    const loadPreview = async () => {
+      try {
+        const translation = await getNewsletterTranslation(newsletterId);
         if (cancelled) return;
-        const first = items[0] ?? null;
-        setPreview(first);
-        if (first?.extractedDate) {
-          const [y, m, d] = first.extractedDate.split('-');
-          setYear(y);
-          setMonth(String(Number(m)));
-          setDay(String(Number(d)));
-        } else {
-          setYear('');
-          setMonth('');
-          setDay('');
+
+        const candidates = translation.dateCandidates ?? [];
+        const title = newsletterTitleRef.current || translation.originalText.slice(0, 20);
+        const events =
+          candidates.length > 0
+            ? candidates.map((c) => ({
+                title,
+                extractedDate: c.normalizedDate,
+                checklistIds: null,
+              }))
+            : [{ title, extractedDate: null, checklistIds: null }];
+
+        await injectCalendarPreviewDummy(newsletterId, events);
+        if (cancelled) return;
+      } catch {
+        // inject 실패해도 preview 조회는 시도
+      }
+
+      try {
+        const items = await getCalendarPreview(newsletterId);
+        if (cancelled) return;
+        setPreviews(items);
+        const states: Record<string, EventState> = {};
+        for (const item of items) {
+          if (item.extractedDate) {
+            const [y, m, d] = item.extractedDate.split('-');
+            states[item.tempEventId] = {
+              year: y,
+              month: String(Number(m)),
+              day: String(Number(d)),
+              isEditing: false,
+            };
+          } else {
+            states[item.tempEventId] = { year: '', month: '', day: '', isEditing: false };
+          }
         }
-      })
-      .catch((e) => {
+        setEventStates(states);
+      } catch (e) {
         if (cancelled) return;
         if (e instanceof CalendarApiError && e.code === 'CAL4042') {
           setPreviewError(i18n.t('scan.result.saveBottomSheet.error.expired'));
         } else {
           setPreviewError(i18n.t('scan.result.saveBottomSheet.error.loadFailed'));
         }
-      })
-      .finally(() => {
+      } finally {
         if (!cancelled) setPreviewLoading(false);
-      });
+      }
+    };
+
+    loadPreview();
 
     return () => {
       cancelled = true;
@@ -215,13 +386,11 @@ const SaveBottomSheet = ({
       keyboardOffset.setValue(0);
       setShow(true);
       setStep('confirm');
-      setIsEditing(false);
       Animated.parallel([
         Animated.timing(opacity, { toValue: 1, duration: 250, useNativeDriver: true }),
         Animated.spring(translateY, { toValue: 0, bounciness: 0, speed: 8, useNativeDriver: true }),
       ]).start();
     } else if (show) {
-      keyboardOffset.setValue(0);
       Animated.parallel([
         Animated.timing(opacity, { toValue: 0, duration: 200, useNativeDriver: true }),
         Animated.timing(translateY, {
@@ -235,7 +404,6 @@ const SaveBottomSheet = ({
     }
   }, [visible, show, opacity, translateY, keyboardOffset]);
 
-  // 키보드 오프셋
   useEffect(() => {
     const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
     const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
@@ -262,109 +430,63 @@ const SaveBottomSheet = ({
     };
   }, [keyboardOffset]);
 
-  const eventTitle = preview?.title ?? '';
-
-  const renderEventCardContent = () => {
-    if (previewLoading) return <ActivityIndicator size="small" color={colors.primary[400]} />;
-    if (previewError) return <Text style={localStyles.errorText}>{previewError}</Text>;
-    return (
-      <>
-        <View style={styles.eventHeader}>
-          <View style={styles.eventDot} />
-          <Text style={styles.eventTitle}>
-            {eventTitle} · {childName}
-          </Text>
-        </View>
-        {dateFound ? (
-          <View style={styles.eventDateRow}>
-            <Text style={styles.eventDate}>{displayDate}</Text>
-            <TouchableOpacity
-              style={styles.editBadge}
-              onPress={() => setIsEditing((v) => !v)}
-              accessibilityRole="button"
-              accessibilityLabel={t('scan.result.saveBottomSheet.accessibilityEdit')}
-            >
-              <Text style={styles.editBadgeText}>{isEditing ? t('scan.result.saveBottomSheet.isEditing') : t('scan.result.saveBottomSheet.edit')}</Text>
-            </TouchableOpacity>
-          </View>
-        ) : (
-          <>
-            <View style={styles.divider} />
-            <DateInputFields
-              year={year}
-              month={month}
-              day={day}
-              onYearChange={setYear}
-              onMonthChange={setMonth}
-              onDayChange={setDay}
-            />
-          </>
-        )}
-      </>
-    );
-  };
-
-  const handleDateConfirm = async () => {
-    const correctedDate = formatCorrectedDate(year, month, day);
-    if (!correctedDate) {
-      Alert.alert(t('scan.result.saveBottomSheet.error.errorTitle'), t('scan.result.saveBottomSheet.error.invalidDate'));
-      return;
-    }
-    if (newsletterId && preview?.tempEventId) {
-      setDatePatching(true);
-      try {
-        await patchCalendarPreviewDates(newsletterId, [
-          { tempEventId: preview.tempEventId, correctedDate },
-        ]);
-      } catch (e) {
-        Alert.alert(t('scan.result.saveBottomSheet.error.dateSaveFailed'), mapPatchError(e));
-        setDatePatching(false);
+  const handleDateConfirmFor = useCallback(
+    (tempEventId: string) => {
+      const es = eventStates[tempEventId];
+      if (!formatCorrectedDate(es.year, es.month, es.day)) {
+        Alert.alert(
+          t('scan.result.saveBottomSheet.error.errorTitle'),
+          t('scan.result.saveBottomSheet.error.invalidDate')
+        );
         return;
       }
-      setDatePatching(false);
-    }
-    setIsEditing(false);
-  };
+      updateEventState(tempEventId, { isEditing: false });
+    },
+    [eventStates, t, updateEventState]
+  );
 
-  const canRegister = !!newsletterId && !!preview && !previewLoading && !previewError;
+  const canRegister = !!newsletterId && previews.length > 0 && !previewLoading && !previewError;
 
-  const handleRegisterConfirm = async () => {
+  const handleRegisterConfirm = useCallback(async () => {
     if (!canRegister) {
-      Alert.alert(t('scan.result.saveBottomSheet.error.registerFailed'), t('scan.result.saveBottomSheet.error.noPreviewMsg'));
+      Alert.alert(
+        t('scan.result.saveBottomSheet.error.registerFailed'),
+        t('scan.result.saveBottomSheet.error.noPreviewMsg')
+      );
       return;
     }
 
-    const startAt = formatCorrectedDate(year, month, day);
-    if (!startAt) {
-      Alert.alert(t('scan.result.saveBottomSheet.error.errorTitle'), t('scan.result.saveBottomSheet.error.invalidDate'));
+    const hasInvalidDate = previews.some((p) => {
+      const es = eventStates[p.tempEventId];
+      return !formatCorrectedDate(es?.year ?? '', es?.month ?? '', es?.day ?? '');
+    });
+    if (hasInvalidDate) {
+      Alert.alert(
+        t('scan.result.saveBottomSheet.error.errorTitle'),
+        t('scan.result.saveBottomSheet.error.invalidDate')
+      );
       return;
-    }
-
-    if (!dateFound && preview.tempEventId) {
-      setDatePatching(true);
-      try {
-        await patchCalendarPreviewDates(newsletterId, [
-          { tempEventId: preview.tempEventId, correctedDate: startAt },
-        ]);
-      } catch (e) {
-        Alert.alert(t('scan.result.saveBottomSheet.error.dateSaveFailed'), mapPatchError(e));
-        setDatePatching(false);
-        return;
-      }
-      setDatePatching(false);
     }
 
     setRegistering(true);
     try {
-      await postCalendarEvents(newsletterId, [
-        { tempEventId: preview.tempEventId, title: preview.title, startAt, endAt: null },
-      ]);
+      const postEvents = previews.map((p) => {
+        const es = eventStates[p.tempEventId];
+        return {
+          tempEventId: p.tempEventId,
+          title: p.title,
+          startAt: formatCorrectedDate(es.year, es.month, es.day) as string,
+          endAt: null,
+        };
+      });
+      await postCalendarEvents(newsletterId!, postEvents);
       setStep('success');
     } catch (e) {
       Alert.alert(t('scan.result.saveBottomSheet.error.registerFailed'), mapRegisterError(e));
+    } finally {
+      setRegistering(false);
     }
-    setRegistering(false);
-  };
+  }, [canRegister, t, previews, eventStates, newsletterId]);
 
   return (
     <Modal visible={show} transparent animationType="none" onRequestClose={onClose}>
@@ -378,11 +500,8 @@ const SaveBottomSheet = ({
       </Animated.View>
 
       <View style={styles.sheetWrap}>
-        <Animated.View style={{ transform: [{ translateY: combinedY }] }}>
-          <View
-            style={[styles.sheet, { paddingBottom: insets.bottom + 20 }]}
-            onStartShouldSetResponder={returnTrue}
-          >
+        <Animated.View style={animatedTransformStyle}>
+          <View style={sheetStyle} onStartShouldSetResponder={returnTrue}>
             <View style={styles.handle} />
 
             <View style={styles.iconWrap}>
@@ -392,81 +511,112 @@ const SaveBottomSheet = ({
             {step === 'success' ? (
               <>
                 <View style={styles.textBlock}>
-                  <Text style={styles.title}>{t('scan.result.saveBottomSheet.successTitle')}</Text>
-                  <Text style={styles.subtitle}>{t('scan.result.saveBottomSheet.successSubtitle')}</Text>
+                  <Text style={styles.title}>
+                    {t('scan.result.saveBottomSheet.successTitle')}
+                  </Text>
+                  <Text style={styles.subtitle}>
+                    {t('scan.result.saveBottomSheet.successSubtitle')}
+                  </Text>
                 </View>
-                <View style={styles.eventCard}>
-                  <View style={styles.eventHeader}>
-                    <View style={styles.eventDot} />
-                    <View style={styles.successEventInfo}>
-                      <Text style={styles.eventTitle}>
-                        {eventTitle} · {childName}
-                      </Text>
-                      <Text style={styles.eventDate}>{displayDate}</Text>
-                    </View>
-                  </View>
-                </View>
+                <ScrollView
+                  style={localStyles.scrollArea}
+                  contentContainerStyle={localStyles.scrollContent}
+                  showsVerticalScrollIndicator={false}
+                  keyboardShouldPersistTaps="handled"
+                >
+                  {previews.map((p) => {
+                    const es = eventStates[p.tempEventId];
+                    return (
+                      <View key={p.tempEventId} style={styles.eventCard}>
+                        <View style={styles.eventHeader}>
+                          <View style={styles.eventDot} />
+                          <View style={styles.successEventInfo}>
+                            <Text style={styles.eventTitle}>{p.title} · {childName}</Text>
+                            {es && (
+                              <Text style={styles.eventDate}>
+                                {getDisplayDate(es.year, es.month, es.day)}
+                              </Text>
+                            )}
+                          </View>
+                        </View>
+                      </View>
+                    );
+                  })}
+                </ScrollView>
                 <PrimaryButton
                   label={t('scan.result.saveBottomSheet.viewCalendar')}
                   onPress={onConfirm}
                   style={STYLE_FULL_WIDTH}
                 />
-                <SecondaryButton label={t('scan.result.saveBottomSheet.close')} onPress={onDismiss} style={STYLE_FULL_WIDTH} />
+                <SecondaryButton
+                  label={t('scan.result.saveBottomSheet.close')}
+                  onPress={onDismiss}
+                  style={STYLE_FULL_WIDTH}
+                />
               </>
             ) : (
               <>
                 <View style={styles.textBlock}>
                   <Text style={styles.title}>{t('scan.result.saveBottomSheet.title')}</Text>
                   <Text style={styles.subtitle}>
-                    {dateFound
-                      ? t('scan.result.saveBottomSheet.subtitleAutoDate')
-                      : t('scan.result.saveBottomSheet.subtitleManualDate')}
+                    {hasAnyMissingDate
+                      ? t('scan.result.saveBottomSheet.subtitleManualDate')
+                      : t('scan.result.saveBottomSheet.subtitleAutoDate')}
                   </Text>
                 </View>
 
-                {!dateFound && (
+                {hasAnyMissingDate && (
                   <View style={styles.warningCard}>
                     <Ionicons name="warning" size={16} color={colors.text.primary} />
-                    <Text style={styles.warningText}>{t('scan.result.saveBottomSheet.dateNotFound')}</Text>
+                    <Text style={styles.warningText}>
+                      {t('scan.result.saveBottomSheet.dateNotFound')}
+                    </Text>
                   </View>
                 )}
 
-                <View style={styles.eventCard}>{renderEventCardContent()}</View>
-
-                {dateFound && isEditing && (
-                  <View style={styles.dateEditorCard}>
-                    <Text style={styles.dateEditorLabel}>{t('scan.result.saveBottomSheet.dateEditor')}</Text>
-                    <DateInputFields
-                      year={year}
-                      month={month}
-                      day={day}
-                      onYearChange={setYear}
-                      onMonthChange={setMonth}
-                      onDayChange={setDay}
+                <ScrollView
+                  style={localStyles.scrollArea}
+                  contentContainerStyle={localStyles.scrollContent}
+                  showsVerticalScrollIndicator={false}
+                  keyboardShouldPersistTaps="handled"
+                >
+                  {previewLoading ? (
+                    <ActivityIndicator
+                      size="small"
+                      color={colors.primary[400]}
+                      style={localStyles.loadingIndicator}
                     />
-                    <TouchableOpacity
-                      style={styles.dateConfirmBtn}
-                      onPress={handleDateConfirm}
-                      disabled={datePatching}
-                      activeOpacity={0.8}
-                      accessibilityRole="button"
-                      accessibilityLabel={t('scan.result.saveBottomSheet.accessibilityDateConfirm')}
-                    >
-                      {datePatching ? (
-                        <ActivityIndicator size="small" color={colors.text.white} />
-                      ) : (
-                        <Text style={styles.dateConfirmBtnText}>{t('scan.result.saveBottomSheet.dateConfirm')}</Text>
-                      )}
-                    </TouchableOpacity>
-                  </View>
-                )}
+                  ) : previewError ? (
+                    <Text style={localStyles.errorText}>{previewError}</Text>
+                  ) : (
+                    previews.map((p) => {
+                      const es = eventStates[p.tempEventId];
+                      if (!es) return null;
+                      return (
+                        <EventCard
+                          key={p.tempEventId}
+                          item={p}
+                          es={es}
+                          childName={childName}
+                          onUpdate={updateEventState}
+                          onDateConfirm={handleDateConfirmFor}
+                          getDisplayDate={getDisplayDate}
+                        />
+                      );
+                    })
+                  )}
+                </ScrollView>
 
                 <View style={styles.buttons}>
-                  <SecondaryButton label={t('scan.result.saveBottomSheet.no')} onPress={onClose} style={STYLE_FLEX_1} />
+                  <SecondaryButton
+                    label={t('scan.result.saveBottomSheet.no')}
+                    onPress={onClose}
+                    style={STYLE_FLEX_1}
+                  />
                   <PrimaryButton
-                    label={datePatching || registering ? '...' : t('scan.result.saveBottomSheet.register')}
+                    label={registering ? '...' : t('scan.result.saveBottomSheet.register')}
                     onPress={handleRegisterConfirm}
-                    disabled={datePatching || registering || !canRegister}
+                    disabled={registering || !canRegister}
                     style={STYLE_FLEX_2}
                   />
                 </View>
@@ -480,12 +630,3 @@ const SaveBottomSheet = ({
 };
 
 export default SaveBottomSheet;
-
-const localStyles = StyleSheet.create({
-  errorText: {
-    fontSize: 13,
-    color: colors.text.secondary,
-    textAlign: 'center',
-    paddingVertical: 8,
-  },
-});


### PR DESCRIPTION
## 📌 작업 내용

- 캘린더 미리보기 더미 주입 API 추가 (`injectCalendarPreviewDummy`, `getCalendarPreview`, `postCalendarEvents`)
- SaveBottomSheet 멀티 이벤트 지원 — 가정통신문 내 복수 날짜를 이벤트 카드별로 개별 표시 및 편집
- 날짜 미추출 이벤트는 사용자가 직접 입력하도록 처리
- PATCH API 제거 — 날짜 수정은 로컬 상태로 유지하다 POST body에 포함
- `newsletterTitleRef` 패턴으로 이중 더미 주입 방지
- `EventCard` 분리 및 `memo` / `useCallback` / `useMemo` 최적화
- 미사용 `React` import 제거, `localStyles` 위치 정리, `find` → `some` 변경

## 📷 스크린 샷

-

## ⚠️ 참고 사항

- AI 파이프라인 연결 전 임시로 더미 주입 방식 사용 중 (`injectCalendarPreviewDummy`)
- Android Modal 내부에서 `KeyboardAvoidingView`가 동작하지 않아 `Keyboard.addListener` 수동 방식으로 처리

## 🔗 관련 이슈

Closes #41 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 여러 이벤트를 한 번에 확인하고 등록할 수 있는 기능 추가
  * 각 이벤트별 날짜 수정 및 확인 기능 개선

* **Refactor**
  * 캘린더 미리보기 처리 방식 개선
  * 저장 시트 UI 및 워크플로우 최적화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GACHI-Project/GACHI-FE/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->