### PR TITLE
✨ [Feature] 홈 화면 API 연동 (#47)

### DIFF
--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -1,7 +1,7 @@
-import { useState, useMemo, useRef, useEffect } from 'react';
+import { useState, useMemo, useRef, useEffect, useCallback } from 'react';
 import { View, Text, ScrollView, TouchableOpacity, ActivityIndicator } from 'react-native';
 import { Ionicons, FontAwesome5 } from '@expo/vector-icons';
-import { router } from 'expo-router';
+import { router, useFocusEffect } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import colors from '../../src/constants/colors';
 import styles from '../../src/styles/calendar/calendar';
@@ -57,6 +57,14 @@ const CalendarScreen = () => {
     month: todayDate.getMonth(),
   });
 
+  const [focusKey, setFocusKey] = useState(0);
+
+  useFocusEffect(
+    useCallback(() => {
+      setFocusKey((k) => k + 1);
+    }, [])
+  );
+
   const weekScrollRef = useRef<ScrollView>(null);
   const weekOffsetRef = useRef(weekOffset);
   const shouldAutoScrollRef = useRef(weekOffset === 0);
@@ -104,7 +112,7 @@ const CalendarScreen = () => {
       .finally(() => {
         if (reqId === weeklyReqIdRef.current) setIsLoading(false);
       });
-  }, [isWeekMode, weekDates, selectedChildName]);
+  }, [isWeekMode, weekDates, selectedChildName, focusKey]);
 
   // 월간 마커
   useEffect(() => {
@@ -120,7 +128,7 @@ const CalendarScreen = () => {
       .finally(() => {
         if (reqId === monthlyReqIdRef.current) setIsLoading(false);
       });
-  }, [isWeekMode, calendarMonth.year, calendarMonth.month, selectedChildName]);
+  }, [isWeekMode, calendarMonth.year, calendarMonth.month, selectedChildName, focusKey]);
 
   // 일간 이벤트
   useEffect(() => {
@@ -136,7 +144,7 @@ const CalendarScreen = () => {
       .finally(() => {
         if (reqId === dailyReqIdRef.current) setIsDailyLoading(false);
       });
-  }, [isWeekMode, selectedDate, selectedChildName]);
+  }, [isWeekMode, selectedDate, selectedChildName, focusKey]);
 
   const markedDatesMap = useMemo(() => {
     const map: Record<string, { dots: { key: string; color: string }[] }> = {};

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -58,9 +58,14 @@ const CalendarScreen = () => {
   });
 
   const [focusKey, setFocusKey] = useState(0);
+  const hasFocusedOnceRef = useRef(false);
 
   useFocusEffect(
     useCallback(() => {
+      if (!hasFocusedOnceRef.current) {
+        hasFocusedOnceRef.current = true;
+        return;
+      }
       setFocusKey((k) => k + 1);
     }, [])
   );

--- a/src/api/checklist.ts
+++ b/src/api/checklist.ts
@@ -1,0 +1,50 @@
+import axios from 'axios';
+import * as SecureStore from 'expo-secure-store';
+import { apiClient } from './auth';
+
+export class ChecklistApiError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string
+  ) {
+    super(message);
+    this.name = 'ChecklistApiError';
+  }
+}
+
+const wrapError = (error: unknown): Error => {
+  if (axios.isAxiosError(error) && error.response?.data?.code) {
+    return new ChecklistApiError(
+      error.response.data.code,
+      error.response.data.message ?? '알 수 없는 오류'
+    );
+  }
+  return error instanceof Error ? error : new Error(String(error));
+};
+
+const getAuthHeader = async () => {
+  const token = await SecureStore.getItemAsync('accessToken');
+  if (!token) throw new ChecklistApiError('UNAUTHORIZED', '로그인이 필요합니다.');
+  return { Authorization: `Bearer ${token}` };
+};
+
+export interface TodayChecklistItem {
+  checklistId: number;
+  content: string;
+  detail: string | null;
+  newsletterTitle: string;
+  childName: string;
+}
+
+export const getTodayChecklists = async (): Promise<TodayChecklistItem[]> => {
+  try {
+    const headers = await getAuthHeader();
+    const response = await apiClient.get<{ result: { checklists: TodayChecklistItem[] } }>(
+      '/api/v1/checklists/today',
+      { headers }
+    );
+    return response.data.result.checklists;
+  } catch (error) {
+    throw wrapError(error);
+  }
+};

--- a/src/api/checklist.ts
+++ b/src/api/checklist.ts
@@ -43,7 +43,23 @@ export const getTodayChecklists = async (): Promise<TodayChecklistItem[]> => {
       '/api/v1/checklists/today',
       { headers }
     );
-    return response.data.result.checklists;
+    return response.data.result.checklists ?? [];
+  } catch (error) {
+    throw wrapError(error);
+  }
+};
+
+export const toggleChecklistItem = async (
+  checklistId: number,
+  isCompleted: boolean
+): Promise<void> => {
+  try {
+    const headers = await getAuthHeader();
+    await apiClient.patch(
+      `/api/v1/checklists/${checklistId}/complete`,
+      { isCompleted },
+      { headers }
+    );
   } catch (error) {
     throw wrapError(error);
   }

--- a/src/api/newsletter.ts
+++ b/src/api/newsletter.ts
@@ -204,3 +204,28 @@ export const getNewsletterStatus = async (
     throw wrapError(error);
   }
 };
+
+export interface RecentNewsletterItem {
+  newsletterId: number;
+  title: string;
+  childName: string | null;
+  childGrade: number | null;
+}
+
+export interface RecentNewsletterGroup {
+  date: string;
+  items: RecentNewsletterItem[];
+}
+
+export const getRecentNewsletters = async (limit = 5): Promise<RecentNewsletterGroup[]> => {
+  try {
+    const headers = await getAuthHeader();
+    const response = await apiClient.get<{ result: { groups: RecentNewsletterGroup[] } }>(
+      '/api/v1/newsletters/recent',
+      { headers, params: { limit } }
+    );
+    return response.data.result.groups ?? [];
+  } catch (error) {
+    throw wrapError(error);
+  }
+};

--- a/src/components/home/RecentDocs.tsx
+++ b/src/components/home/RecentDocs.tsx
@@ -1,61 +1,34 @@
-import { View, Text, TouchableOpacity } from 'react-native';
+import { useState, useEffect } from 'react';
+import { View, Text, TouchableOpacity, ActivityIndicator } from 'react-native';
 import { AntDesign, Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
+import { getRecentNewsletters, type RecentNewsletterGroup } from '../../api/newsletter';
 import colors from '../../constants/colors';
 import styles from '../../styles/home/recentDocs';
 
-interface DocItem {
-  id: string;
-  title: string;
-  childName: string;
-  grade: string;
-  rawDate: string;
-}
-
-interface DocGroup {
-  date: string;
-  rawDate: string;
-  items: DocItem[];
-}
-
-const RECENT_DOCS: DocGroup[] = [
-  {
-    date: '3월 20일',
-    rawDate: '2025-03-20',
-    items: [
-      {
-        id: '1',
-        title: '학부모 상담 안내문',
-        childName: '김둘째',
-        grade: '초등학교 1학년',
-        rawDate: '2025-03-20',
-      },
-    ],
-  },
-  {
-    date: '3월 18일',
-    rawDate: '2025-03-18',
-    items: [
-      {
-        id: '2',
-        title: '학부모 상담 안내문',
-        childName: '김둘째',
-        grade: '초등학교 1학년',
-        rawDate: '2025-03-18',
-      },
-      {
-        id: '3',
-        title: '학부모 상담 안내문',
-        childName: '김둘째',
-        grade: '초등학교 1학년',
-        rawDate: '2025-03-18',
-      },
-    ],
-  },
-];
+const formatGroupDate = (dateStr: string, locale: string) =>
+  new Intl.DateTimeFormat(locale, { month: 'long', day: 'numeric' }).format(new Date(dateStr));
 
 const RecentDocs = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const [groups, setGroups] = useState<RecentNewsletterGroup[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    getRecentNewsletters(5)
+      .then((data) => {
+        if (!cancelled) setGroups(data);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <View style={styles.section}>
       <View style={styles.header}>
@@ -65,48 +38,64 @@ const RecentDocs = () => {
           <Text style={styles.moreText}>{t('home.recentDocs.more')}</Text>
         </TouchableOpacity>
       </View>
-      <View style={styles.timeline}>
-        {RECENT_DOCS.map((group) => (
-          <View key={group.rawDate} style={styles.group}>
-            <View style={styles.dateRow}>
-              <View style={styles.dateDot} />
-              <Text style={styles.dateText}>{group.date}</Text>
-            </View>
-            <View style={styles.timelineBody}>
-              <View style={styles.lineColumn}>
-                <View style={styles.line} />
+
+      {loading ? (
+        <ActivityIndicator size="small" color={colors.primary[400]} style={{ marginVertical: 16 }} />
+      ) : groups.length === 0 ? (
+        <Text style={styles.docMeta}>{t('document.empty')}</Text>
+      ) : (
+        <View style={styles.timeline}>
+          {groups.map((group) => (
+            <View key={group.date} style={styles.group}>
+              <View style={styles.dateRow}>
+                <View style={styles.dateDot} />
+                <Text style={styles.dateText}>
+                  {formatGroupDate(group.date, i18n.language)}
+                </Text>
               </View>
-              <View style={styles.cardsArea}>
-                {group.items.map((doc) => (
-                  // TODO: 문서 상세 화면으로 이동 예정 router.push(`/(tabs)/documents/${doc.id}`)
-                  <TouchableOpacity
-                    key={doc.id}
-                    style={styles.docCard}
-                    activeOpacity={0.8}
-                    onPress={() => {}}
-                  >
-                    <View style={styles.docIconBox}>
-                      <AntDesign
-                        name="file-done"
-                        size={25}
-                        color={colors.text.white}
-                        style={styles.docIcon}
-                      />
-                    </View>
-                    <View style={styles.docTexts}>
-                      <Text style={styles.docTitle}>{doc.title}</Text>
-                      <Text style={styles.docMeta}>
-                        {doc.childName} · {doc.grade}
-                      </Text>
-                    </View>
-                    <Ionicons name="chevron-forward" size={24} color={colors.gray[200]} />
-                  </TouchableOpacity>
-                ))}
+              <View style={styles.timelineBody}>
+                <View style={styles.lineColumn}>
+                  <View style={styles.line} />
+                </View>
+                <View style={styles.cardsArea}>
+                  {group.items.map((doc) => (
+                    // TODO: 문서 상세 화면으로 이동 예정 router.push(`/(tabs)/documents/${doc.newsletterId}`)
+                    <TouchableOpacity
+                      key={doc.newsletterId}
+                      style={styles.docCard}
+                      activeOpacity={0.8}
+                      onPress={() => {}}
+                    >
+                      <View style={styles.docIconBox}>
+                        <AntDesign
+                          name="file-done"
+                          size={25}
+                          color={colors.text.white}
+                          style={styles.docIcon}
+                        />
+                      </View>
+                      <View style={styles.docTexts}>
+                        <Text style={styles.docTitle}>{doc.title}</Text>
+                        <Text style={styles.docMeta}>
+                          {[
+                            doc.childName,
+                            doc.childGrade != null
+                              ? t('common.elementaryGrade', { grade: doc.childGrade })
+                              : null,
+                          ]
+                            .filter(Boolean)
+                            .join(' · ')}
+                        </Text>
+                      </View>
+                      <Ionicons name="chevron-forward" size={24} color={colors.gray[200]} />
+                    </TouchableOpacity>
+                  ))}
+                </View>
               </View>
             </View>
-          </View>
-        ))}
-      </View>
+          ))}
+        </View>
+      )}
     </View>
   );
 };

--- a/src/components/home/RecentDocs.tsx
+++ b/src/components/home/RecentDocs.tsx
@@ -13,6 +13,7 @@ const RecentDocs = () => {
   const { t, i18n } = useTranslation();
   const [groups, setGroups] = useState<RecentNewsletterGroup[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -20,7 +21,9 @@ const RecentDocs = () => {
       .then((data) => {
         if (!cancelled) setGroups(data);
       })
-      .catch(() => {})
+      .catch(() => {
+        if (!cancelled) setError(true);
+      })
       .finally(() => {
         if (!cancelled) setLoading(false);
       });
@@ -41,6 +44,8 @@ const RecentDocs = () => {
 
       {loading ? (
         <ActivityIndicator size="small" color={colors.primary[400]} style={{ marginVertical: 16 }} />
+      ) : error ? (
+        <Text style={styles.docMeta}>{t('common.networkError')}</Text>
       ) : groups.length === 0 ? (
         <Text style={styles.docMeta}>{t('document.empty')}</Text>
       ) : (

--- a/src/components/home/TaskCard.tsx
+++ b/src/components/home/TaskCard.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { View, Text, TouchableOpacity, ActivityIndicator } from 'react-native';
 import { router } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { getTodayChecklists, type TodayChecklistItem } from '../../api/checklist';
+import { getTodayChecklists, toggleChecklistItem, type TodayChecklistItem } from '../../api/checklist';
 import { getMyChildren, type ChildResult } from '../../api/child';
 import colors from '../../constants/colors';
 import styles from '../../styles/home/taskCard';
@@ -14,6 +14,7 @@ const TaskCard = () => {
   const [items, setItems] = useState<TodayChecklistItem[]>([]);
   const [children, setChildren] = useState<ChildResult[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
   const [checked, setChecked] = useState<Record<number, boolean>>({});
 
   useEffect(() => {
@@ -25,7 +26,9 @@ const TaskCard = () => {
           setChildren(childList);
         }
       })
-      .catch(() => {})
+      .catch(() => {
+        if (!cancelled) setError(true);
+      })
       .finally(() => {
         if (!cancelled) setLoading(false);
       });
@@ -77,7 +80,13 @@ const TaskCard = () => {
     };
   }, []);
 
-  const toggleCheck = (id: number) => setChecked((prev) => ({ ...prev, [id]: !prev[id] }));
+  const toggleCheck = useCallback((id: number, currentChecked: boolean) => {
+    const next = !currentChecked;
+    setChecked((prev) => ({ ...prev, [id]: next }));
+    toggleChecklistItem(id, next).catch(() => {
+      setChecked((prev) => ({ ...prev, [id]: !next }));
+    });
+  }, []);
 
   return (
     <View style={styles.card}>
@@ -114,6 +123,8 @@ const TaskCard = () => {
 
       {loading ? (
         <ActivityIndicator size="small" color={colors.primary[400]} style={{ marginVertical: 16 }} />
+      ) : error ? (
+        <Text style={styles.emptyText}>{t('common.networkError')}</Text>
       ) : total === 0 ? (
         <Text style={styles.emptyText}>{t('home.taskCard.empty')}</Text>
       ) : (
@@ -122,8 +133,11 @@ const TaskCard = () => {
             <View style={styles.todoRow}>
               <TouchableOpacity
                 style={[styles.checkbox, checked[item.checklistId] && styles.checkboxChecked]}
-                onPress={() => toggleCheck(item.checklistId)}
+                onPress={() => toggleCheck(item.checklistId, !!checked[item.checklistId])}
                 activeOpacity={0.7}
+                accessibilityRole="checkbox"
+                accessibilityState={{ checked: !!checked[item.checklistId] }}
+                accessibilityLabel={item.content}
               >
                 {checked[item.checklistId] && <Text style={styles.checkMark}>✓</Text>}
               </TouchableOpacity>
@@ -158,6 +172,8 @@ const TaskCard = () => {
           <TouchableOpacity
             style={styles.moreButton}
             activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel={t('home.taskCard.moreItems', { count: hiddenCount })}
             onPress={() => router.push('/(tabs)/calendar')}
           >
             <Text style={styles.moreText}>

--- a/src/components/home/TaskCard.tsx
+++ b/src/components/home/TaskCard.tsx
@@ -1,64 +1,73 @@
-import { useState, useMemo } from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
+import { useState, useEffect, useMemo } from 'react';
+import { View, Text, TouchableOpacity, ActivityIndicator } from 'react-native';
 import { router } from 'expo-router';
 import { useTranslation } from 'react-i18next';
+import { getTodayChecklists, type TodayChecklistItem } from '../../api/checklist';
+import { getMyChildren, type ChildResult } from '../../api/child';
+import colors from '../../constants/colors';
 import styles from '../../styles/home/taskCard';
-
-interface Child {
-  id: string;
-  color: string;
-}
-
-interface TodoItem {
-  id: string;
-  title: string;
-  childName: string;
-  childId: string;
-  description: string;
-}
-
-const CHILDREN: Child[] = [
-  { id: '1', color: '#26DE81' },
-  { id: '2', color: '#FFCC2F' },
-];
-
-const TODO_ITEMS: TodoItem[] = [
-  {
-    id: '1',
-    title: '현장학습 동의서 제출',
-    childName: '첫째',
-    childId: '1',
-    description: '담임 선생님께 오늘까지',
-  },
-  {
-    id: '2',
-    title: '학부모 상담 신청',
-    childName: '둘째',
-    childId: '2',
-    description: '오늘까지 상담 시간 신청',
-  },
-];
 
 const VISIBLE_COUNT = 2;
 
 const TaskCard = () => {
   const { t } = useTranslation();
-  const [checked, setChecked] = useState<Record<string, boolean>>({});
+  const [items, setItems] = useState<TodayChecklistItem[]>([]);
+  const [children, setChildren] = useState<ChildResult[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [checked, setChecked] = useState<Record<number, boolean>>({});
 
-  const total = TODO_ITEMS.length;
-  const visibleItems = TODO_ITEMS.slice(0, VISIBLE_COUNT);
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([getTodayChecklists(), getMyChildren()])
+      .then(([checklists, childList]) => {
+        if (!cancelled) {
+          setItems(checklists);
+          setChildren(childList);
+        }
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const colorMap = useMemo(() => {
+    const map: Record<string, string> = {};
+    children.forEach((c) => {
+      map[c.name] = c.colorCode;
+    });
+    return map;
+  }, [children]);
+
+  const total = items.length;
+  const visibleItems = items.slice(0, VISIBLE_COUNT);
   const hiddenCount = Math.max(total - VISIBLE_COUNT, 0);
+
+  const distinctChildNames = useMemo(() => {
+    const seen = new Set<string>();
+    const result: string[] = [];
+    items.forEach((item) => {
+      if (!seen.has(item.childName)) {
+        seen.add(item.childName);
+        result.push(item.childName);
+      }
+    });
+    return result;
+  }, [items]);
+
   const summaryDesc = useMemo(() => {
     if (total === 0) return t('home.taskCard.todayEmpty');
-    const childCounts = CHILDREN.map((child) => ({
-      name: TODO_ITEMS.find((item) => item.childId === child.id)?.childName ?? '',
-      count: TODO_ITEMS.filter((item) => item.childId === child.id).length,
-    }));
-    return `${childCounts
-      .filter((c) => c.count > 0)
-      .map((c) => t('home.taskCard.childCount', { name: c.name, count: c.count }))
+    const grouped: Record<string, number> = {};
+    items.forEach((item) => {
+      grouped[item.childName] = (grouped[item.childName] ?? 0) + 1;
+    });
+    return `${Object.entries(grouped)
+      .map(([name, count]) => t('home.taskCard.childCount', { name, count }))
       .join(' · ')} ${t('home.taskCard.remaining')}`;
-  }, [t]);
+  }, [items, t]);
 
   const { todayMonth, todayDay } = useMemo(() => {
     const now = new Date();
@@ -68,11 +77,10 @@ const TaskCard = () => {
     };
   }, []);
 
-  const toggleCheck = (id: string) => setChecked((prev) => ({ ...prev, [id]: !prev[id] }));
+  const toggleCheck = (id: number) => setChecked((prev) => ({ ...prev, [id]: !prev[id] }));
 
   return (
     <View style={styles.card}>
-      {/* Summary row */}
       <View style={styles.summaryRow}>
         <View style={styles.dateBadge}>
           <Text style={styles.dateMonth}>{todayMonth}</Text>
@@ -80,19 +88,21 @@ const TaskCard = () => {
         </View>
         <View style={styles.summaryTexts}>
           <Text style={styles.summaryTitle}>
-            {total === 0
-              ? t('home.taskCard.noTodo')
-              : t('home.taskCard.todayCount', { count: total })}
+            {loading
+              ? ''
+              : total === 0
+                ? t('home.taskCard.noTodo')
+                : t('home.taskCard.todayCount', { count: total })}
           </Text>
-          <Text style={styles.summaryDesc}>{summaryDesc}</Text>
+          {!loading && <Text style={styles.summaryDesc}>{summaryDesc}</Text>}
         </View>
         <View style={styles.childCircles}>
-          {CHILDREN.map((child, index) => (
+          {distinctChildNames.map((name, index) => (
             <View
-              key={child.id}
+              key={name}
               style={[
                 styles.childCircle,
-                { backgroundColor: child.color },
+                { backgroundColor: colorMap[name] ?? colors.primary[300] },
                 index > 0 && styles.childCircleOverlap,
               ]}
             />
@@ -102,34 +112,35 @@ const TaskCard = () => {
 
       <View style={styles.divider} />
 
-      {/* Todo items */}
-      {total === 0 ? (
+      {loading ? (
+        <ActivityIndicator size="small" color={colors.primary[400]} style={{ marginVertical: 16 }} />
+      ) : total === 0 ? (
         <Text style={styles.emptyText}>{t('home.taskCard.empty')}</Text>
       ) : (
         visibleItems.map((item, index) => (
-          <View key={item.id}>
+          <View key={item.checklistId}>
             <View style={styles.todoRow}>
               <TouchableOpacity
-                style={[styles.checkbox, checked[item.id] && styles.checkboxChecked]}
-                onPress={() => toggleCheck(item.id)}
+                style={[styles.checkbox, checked[item.checklistId] && styles.checkboxChecked]}
+                onPress={() => toggleCheck(item.checklistId)}
                 activeOpacity={0.7}
               >
-                {checked[item.id] && <Text style={styles.checkMark}>✓</Text>}
+                {checked[item.checklistId] && <Text style={styles.checkMark}>✓</Text>}
               </TouchableOpacity>
               <View style={styles.todoContent}>
-                <Text style={[styles.todoTitle, checked[item.id] && styles.todoTitleDone]}>
-                  {item.title}
+                <Text style={[styles.todoTitle, checked[item.checklistId] && styles.todoTitleDone]}>
+                  {item.content}
                 </Text>
                 <View style={styles.todoMeta}>
                   <View
                     style={[
                       styles.childTag,
-                      { backgroundColor: CHILDREN.find((c) => c.id === item.childId)?.color },
+                      { backgroundColor: colorMap[item.childName] ?? colors.primary[300] },
                     ]}
                   >
                     <Text style={styles.childTagText}>{item.childName}</Text>
                   </View>
-                  <Text style={styles.todoDesc}>{item.description}</Text>
+                  {item.detail ? <Text style={styles.todoDesc}>{item.detail}</Text> : null}
                 </View>
               </View>
               <View style={styles.todayBadge}>

--- a/src/components/home/TaskCard.tsx
+++ b/src/components/home/TaskCard.tsx
@@ -16,12 +16,14 @@ const TaskCard = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [checked, setChecked] = useState<Record<number, boolean>>({});
+  const [pendingIds, setPendingIds] = useState<Record<number, boolean>>({});
   const [focusKey, setFocusKey] = useState(0);
 
   useFocusEffect(
     useCallback(() => {
       setFocusKey((k) => k + 1);
       setChecked({});
+      setPendingIds({});
     }, [])
   );
 
@@ -90,13 +92,22 @@ const TaskCard = () => {
     };
   }, []);
 
-  const toggleCheck = useCallback((id: number, currentChecked: boolean) => {
-    const next = !currentChecked;
-    setChecked((prev) => ({ ...prev, [id]: next }));
-    toggleChecklistItem(id, next).catch(() => {
-      setChecked((prev) => ({ ...prev, [id]: !next }));
-    });
-  }, []);
+  const toggleCheck = useCallback(
+    (id: number, currentChecked: boolean) => {
+      if (pendingIds[id]) return;
+      const next = !currentChecked;
+      setChecked((prev) => ({ ...prev, [id]: next }));
+      setPendingIds((prev) => ({ ...prev, [id]: true }));
+      toggleChecklistItem(id, next)
+        .catch(() => {
+          setChecked((prev) => ({ ...prev, [id]: !next }));
+        })
+        .finally(() => {
+          setPendingIds((prev) => ({ ...prev, [id]: false }));
+        });
+    },
+    [pendingIds]
+  );
 
   return (
     <View style={styles.card}>
@@ -107,13 +118,13 @@ const TaskCard = () => {
         </View>
         <View style={styles.summaryTexts}>
           <Text style={styles.summaryTitle}>
-            {loading
+            {loading || error
               ? ''
               : total === 0
                 ? t('home.taskCard.noTodo')
                 : t('home.taskCard.todayCount', { count: total })}
           </Text>
-          {!loading && <Text style={styles.summaryDesc}>{summaryDesc}</Text>}
+          {!loading && !error && <Text style={styles.summaryDesc}>{summaryDesc}</Text>}
         </View>
         <View style={styles.childCircles}>
           {distinctChildNames.map((name, index) => (
@@ -145,8 +156,9 @@ const TaskCard = () => {
                 style={[styles.checkbox, checked[item.checklistId] && styles.checkboxChecked]}
                 onPress={() => toggleCheck(item.checklistId, !!checked[item.checklistId])}
                 activeOpacity={0.7}
+                disabled={!!pendingIds[item.checklistId]}
                 accessibilityRole="checkbox"
-                accessibilityState={{ checked: !!checked[item.checklistId] }}
+                accessibilityState={{ checked: !!checked[item.checklistId], busy: !!pendingIds[item.checklistId] }}
                 accessibilityLabel={item.content}
               >
                 {checked[item.checklistId] && <Text style={styles.checkMark}>✓</Text>}

--- a/src/components/home/TaskCard.tsx
+++ b/src/components/home/TaskCard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { View, Text, TouchableOpacity, ActivityIndicator } from 'react-native';
-import { router } from 'expo-router';
+import { router, useFocusEffect } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { getTodayChecklists, toggleChecklistItem, type TodayChecklistItem } from '../../api/checklist';
 import { getMyChildren, type ChildResult } from '../../api/child';
@@ -16,9 +16,19 @@ const TaskCard = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [checked, setChecked] = useState<Record<number, boolean>>({});
+  const [focusKey, setFocusKey] = useState(0);
+
+  useFocusEffect(
+    useCallback(() => {
+      setFocusKey((k) => k + 1);
+      setChecked({});
+    }, [])
+  );
 
   useEffect(() => {
     let cancelled = false;
+    setLoading(true);
+    setError(false);
     Promise.all([getTodayChecklists(), getMyChildren()])
       .then(([checklists, childList]) => {
         if (!cancelled) {
@@ -35,7 +45,7 @@ const TaskCard = () => {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [focusKey]);
 
   const colorMap = useMemo(() => {
     const map: Record<string, string> = {};


### PR DESCRIPTION
## 📌 작업 내용

- `GET /api/v1/checklists/today` 연동 — 오늘 마감 미완료 체크리스트 조회
- `PATCH /api/v1/checklists/{checklistId}/complete` 연동 — 체크 완료 토글 (낙관적 업데이트 + 실패 시 롤백)
- `GET /api/v1/newsletters/recent` 연동 — 최근 가정통신문 조회
- TaskCard / RecentDocs 더미 데이터 → API 응답으로 교체
- 로딩 / 에러 / 빈 상태 처리 추가
- 홈 탭 포커스 시 체크리스트 재조회 및 체크 state 초기화
- 캘린더 탭 포커스 시 이벤트 데이터 재조회

## 📷 스크린 샷

| 화면 1 | 화면 2 |
|---|---|
| <img width="300" alt="Screenshot_1779641319" src="https://github.com/user-attachments/assets/59c61a88-7b62-46d8-a7be-b53409deb91b" /> | <img width="300" alt="Screenshot_1779641323" src="https://github.com/user-attachments/assets/c0ed9c8e-7281-4e45-8e0f-af00a76b847c" /> |

## ⚠️ 참고 사항

- 체크 완료 후 홈 탭 재진입 시 완료 항목은 목록에서 제외됨 (API가 미완료 항목만 반환)
- 가정통신문 상세 화면 이동은 미구현 (TODO 주석으로 표시)

## 🔗 관련 이슈

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 달력 탭 진입 시 포커스 전환에 맞춰 데이터가 자동으로 새로고침됩니다

* **개선 사항**
  * 최근 문서 목록을 서버에서 동적으로 로드해 실시간 콘텐츠를 표시합니다
  * 일일 작업(체크리스트)을 서버에서 동적으로 로드합니다
  * 작업 완료 토글은 즉시 반영(낙관적 업데이트)되며 실패 시 자동 롤백됩니다
  * 로딩/오류/빈 상태 처리, 접근성 레이블 및 날짜 지역화 표시가 개선되었습니다

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GACHI-Project/GACHI-FE/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->