### PR TITLE
✨ [Feature] accessToken 자동 재발급 인터셉터 구현

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,4 +1,6 @@
 import axios from 'axios';
+import * as SecureStore from 'expo-secure-store';
+import { router } from 'expo-router';
 
 export class AuthApiError extends Error {
   constructor(
@@ -25,6 +27,67 @@ export const apiClient = axios.create({
   headers: { 'Content-Type': 'application/json' },
   timeout: 10000,
 });
+
+let isRefreshing = false;
+let failedQueue: Array<{ resolve: (token: string) => void; reject: (error: unknown) => void }> = [];
+
+const processQueue = (error: unknown, token: string | null = null) => {
+  failedQueue.forEach(({ resolve, reject }) => {
+    if (error) reject(error);
+    else resolve(token!);
+  });
+  failedQueue = [];
+};
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config as typeof error.config & { _retry?: boolean };
+
+    if (error.response?.status !== 401 || originalRequest._retry) {
+      return Promise.reject(error);
+    }
+
+    if (isRefreshing) {
+      return new Promise<string>((resolve, reject) => {
+        failedQueue.push({ resolve, reject });
+      }).then((token) => {
+        originalRequest.headers.Authorization = `Bearer ${token}`;
+        return apiClient(originalRequest);
+      });
+    }
+
+    originalRequest._retry = true;
+    isRefreshing = true;
+
+    try {
+      const storedRefresh = await SecureStore.getItemAsync('refreshToken');
+      if (!storedRefresh) throw new Error('no_refresh_token');
+
+      const { data } = await axios.post(
+        `${apiClient.defaults.baseURL}/api/v1/auth/reissue`,
+        { refreshToken: storedRefresh },
+        { headers: { 'Content-Type': 'application/json' } }
+      );
+      const { accessToken, refreshToken: newRefresh } = data.result;
+
+      await SecureStore.setItemAsync('accessToken', accessToken);
+      await SecureStore.setItemAsync('refreshToken', newRefresh);
+
+      processQueue(null, accessToken);
+      originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+      return apiClient(originalRequest);
+    } catch (refreshError) {
+      processQueue(refreshError, null);
+      await SecureStore.deleteItemAsync('accessToken');
+      await SecureStore.deleteItemAsync('refreshToken');
+      router.replace('/(auth)/login');
+      return Promise.reject(refreshError);
+    } finally {
+      isRefreshing = false;
+    }
+  }
+);
 
 export const checkLoginId = async (loginId: string): Promise<{ available: boolean }> => {
   try {

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -52,6 +52,7 @@ apiClient.interceptors.response.use(
       return new Promise<string>((resolve, reject) => {
         failedQueue.push({ resolve, reject });
       }).then((token) => {
+        originalRequest._retry = true;
         originalRequest.headers.Authorization = `Bearer ${token}`;
         return apiClient(originalRequest);
       });
@@ -62,7 +63,7 @@ apiClient.interceptors.response.use(
 
     try {
       const storedRefresh = await SecureStore.getItemAsync('refreshToken');
-      if (!storedRefresh) throw new Error('no_refresh_token');
+      if (!storedRefresh) return Promise.reject(error);
 
       const { data } = await axios.post(
         `${apiClient.defaults.baseURL}/api/v1/auth/reissue`,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -261,7 +261,7 @@
       "sectionTitle": "Key Features",
       "ai": {
         "title": ["Ask", "AI"],
-        "desc": "Ask questions about anything unclear. AI will explain the full context too.",
+        "desc": "Ask questions about anything unclear. AI will explain the full context.",
         "button": "Start Chat"
       },
       "guide": {
@@ -435,7 +435,7 @@
       },
       "aiSummary": {
         "summarySection": "AI Summary",
-        "todayTodo": "Today's Tasks",
+        "todayTodo": "Todo",
         "culturalContext": "Cultural Context",
         "emptyTodo": "No tasks yet.",
         "error": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -435,7 +435,7 @@
       },
       "aiSummary": {
         "summarySection": "AI 요약",
-        "todayTodo": "오늘 할 일",
+        "todayTodo": "해야 할 일",
         "culturalContext": "문화 맥락 안내",
         "emptyTodo": "등록된 할 일이 없어요.",
         "error": {


### PR DESCRIPTION
## 📌 작업 내용

- accessToken 만료 시 refreshToken으로 자동 재발급 후 원래 요청 재시도
- 동시에 여러 요청이 401 되는 경우 failedQueue로 한 번만 재발급 후 일괄 재시도
- refresh 실패 시 토큰 삭제 및 로그인 화면으로 강제 이동

## 📷 스크린 샷

-

## ⚠️ 참고 사항

- reissue 요청은 apiClient 대신 axios.post 직접 호출로 인터셉터 무한루프 방지

## 🔗 관련 이슈

Closes #55 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 인증 토큰 자동 갱신 기능 추가 - 만료된 토큰이 자동으로 재발급되어 사용자 세션이 끊기지 않습니다.

* **Style**
  * UI 텍스트 문구 조정 - 화면 텍스트의 명확성을 개선했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GACHI-Project/GACHI-FE/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->