### PR TITLE
✨ [Feature] 내 정보 조회 및 알림 설정 변경 API 연동 (#62)

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -14,17 +14,18 @@ import { router } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { ChildInfo } from '../../src/types/child';
 import { fetchChildren, registerChild, ChildItem } from '../../src/api/child';
+import { fetchMyInfo, UserInfo } from '../../src/api/user';
 import { CALENDAR_COLORS } from '../../src/constants/child';
 import colors from '../../src/constants/colors';
 import styles from '../../src/styles/profile/profile';
 import Header from '../../src/components/common/Header';
 import ChildEditSheet from '../../src/components/profile/ChildEditSheet';
 
-const mockUser = {
-  name: 'Linh Nguyễn',
-  loginId: 'gachi-gayo22',
-  joinDate: '2026.01',
+const formatJoinDate = (iso: string) => {
+  const d = new Date(iso);
+  return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, '0')}`;
 };
+
 const LANGUAGE_NAMES: Record<string, string> = {
   ko: '한국어',
   en: 'English',
@@ -32,12 +33,12 @@ const LANGUAGE_NAMES: Record<string, string> = {
   zh: '中文',
 };
 
-const mockNotification = true;
 const APP_VERSION = '1.0.0';
 
 const ProfileScreen = () => {
   const { t, i18n } = useTranslation();
   const currentLanguageName = LANGUAGE_NAMES[i18n.language] ?? i18n.language;
+  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
   const [children, setChildren] = useState<ChildItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [editingChild, setEditingChild] = useState<ChildInfo | null>(null);
@@ -55,6 +56,12 @@ const ProfileScreen = () => {
       } finally {
         setIsLoading(false);
       }
+      try {
+        const user = await fetchMyInfo();
+        setUserInfo(user);
+      } catch (e) {
+        console.error('사용자 정보 조회 실패:', e);
+      }
     };
     load();
   }, []);
@@ -67,13 +74,15 @@ const ProfileScreen = () => {
           <Image source={require('../../assets/icon.png')} style={styles.avatar} />
 
           <View style={styles.profileInfo}>
-            <Text style={styles.profileName}>{mockUser.name}</Text>
+            <Text style={styles.profileName}>{userInfo?.name ?? ''}</Text>
             <View style={styles.profileSubRow}>
               <View style={styles.idBadge}>
-                <Text style={styles.idBadgeText}>{mockUser.loginId}</Text>
+                <Text style={styles.idBadgeText}>{userInfo?.loginId ?? ''}</Text>
               </View>
               <Text style={styles.joinDate}>
-                {t('profile.joinDate', { date: mockUser.joinDate })}
+                {t('profile.joinDate', {
+                  date: userInfo ? formatJoinDate(userInfo.createdAt) : '',
+                })}
               </Text>
             </View>
           </View>
@@ -156,7 +165,9 @@ const ProfileScreen = () => {
           >
             <Text style={styles.rowLabel}>{t('profile.notification')}</Text>
             <Text style={styles.rowValue}>
-              {mockNotification ? t('profile.notificationOn') : t('profile.notificationOff')}
+              {userInfo?.notificationEnabled
+                ? t('profile.notificationOn')
+                : t('profile.notificationOff')}
             </Text>
             <Ionicons name="chevron-forward" size={16} color={colors.text.secondary} />
           </TouchableOpacity>

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import {
   ScrollView,
   View,
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 import * as SecureStore from 'expo-secure-store';
 import { Ionicons } from '@expo/vector-icons';
-import { router } from 'expo-router';
+import { router, useFocusEffect } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { ChildInfo } from '../../src/types/child';
 import { fetchChildren, registerChild, ChildItem } from '../../src/api/child';
@@ -56,15 +56,17 @@ const ProfileScreen = () => {
       } finally {
         setIsLoading(false);
       }
-      try {
-        const user = await fetchMyInfo();
-        setUserInfo(user);
-      } catch (e) {
-        console.error('사용자 정보 조회 실패:', e);
-      }
     };
     load();
   }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      fetchMyInfo()
+        .then(setUserInfo)
+        .catch(() => {});
+    }, [])
+  );
 
   return (
     <View style={styles.container}>
@@ -165,9 +167,9 @@ const ProfileScreen = () => {
           >
             <Text style={styles.rowLabel}>{t('profile.notification')}</Text>
             <Text style={styles.rowValue}>
-              {userInfo?.notificationEnabled
-                ? t('profile.notificationOn')
-                : t('profile.notificationOff')}
+              {userInfo?.notificationPreference === 'OFF'
+                ? t('profile.notificationOff')
+                : t('profile.notificationOn')}
             </Text>
             <Ionicons name="chevron-forward" size={16} color={colors.text.secondary} />
           </TouchableOpacity>

--- a/app/profile/edit.tsx
+++ b/app/profile/edit.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -12,19 +12,20 @@ import { Ionicons, FontAwesome5 } from '@expo/vector-icons';
 import { router } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import Header from '../../src/components/common/Header';
+import { fetchMyInfo, UserInfo } from '../../src/api/user';
 import colors from '../../src/constants/colors';
 import styles from '../../src/styles/profile/profileEdit';
-
-const mockUser = {
-  loginId: 'gachi-gayo22',
-  name: 'Linh Nguyễn',
-  phone: '010-0000-0000',
-  email: 'gachi-gayo@example.com',
-};
 
 const ProfileEditScreen = () => {
   const { t } = useTranslation();
   const [withdrawModalVisible, setWithdrawModalVisible] = useState(false);
+  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+
+  useEffect(() => {
+    fetchMyInfo()
+      .then(setUserInfo)
+      .catch((e) => console.error('사용자 정보 조회 실패:', e));
+  }, []);
 
   return (
     <View style={styles.container}>
@@ -32,24 +33,24 @@ const ProfileEditScreen = () => {
       <ScrollView style={styles.scroll} showsVerticalScrollIndicator={false}>
         <View style={styles.profileCard}>
           <Image source={require('../../assets/icon.png')} style={styles.avatar} />
-          <Text style={styles.loginId}>{mockUser.loginId}</Text>
+          <Text style={styles.loginId}>{userInfo?.loginId ?? ''}</Text>
         </View>
 
         <Text style={styles.sectionLabel}>{t('profile.editProfile.accountSection')}</Text>
         <View style={styles.card}>
           <View style={styles.row}>
             <Text style={styles.rowLabel}>{t('profile.editProfile.name')}</Text>
-            <Text style={styles.rowValue}>{mockUser.name}</Text>
+            <Text style={styles.rowValue}>{userInfo?.name ?? ''}</Text>
           </View>
           <View style={styles.divider} />
           <View style={styles.row}>
             <Text style={styles.rowLabel}>{t('profile.editProfile.phone')}</Text>
-            <Text style={styles.rowValue}>{mockUser.phone}</Text>
+            <Text style={styles.rowValue}>—</Text>
           </View>
           <View style={styles.divider} />
           <View style={styles.row}>
             <Text style={styles.rowLabel}>{t('profile.editProfile.email')}</Text>
-            <Text style={styles.rowValue}>{mockUser.email}</Text>
+            <Text style={styles.rowValue}>{userInfo?.email ?? ''}</Text>
           </View>
         </View>
 

--- a/app/profile/edit.tsx
+++ b/app/profile/edit.tsx
@@ -45,7 +45,7 @@ const ProfileEditScreen = () => {
           <View style={styles.divider} />
           <View style={styles.row}>
             <Text style={styles.rowLabel}>{t('profile.editProfile.phone')}</Text>
-            <Text style={styles.rowValue}>—</Text>
+            <Text style={styles.rowValue}>{userInfo?.phoneNumber ?? ''}</Text>
           </View>
           <View style={styles.divider} />
           <View style={styles.row}>

--- a/app/profile/notification.tsx
+++ b/app/profile/notification.tsx
@@ -1,10 +1,15 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { View, Text, ScrollView, TouchableOpacity } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { router } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import Header from '../../src/components/common/Header';
 import Toggle from '../../src/components/common/Toggle';
+import {
+  fetchMyInfo,
+  updateNotificationPreference,
+  type NotificationPreference,
+} from '../../src/api/user';
 import colors from '../../src/constants/colors';
 import styles from '../../src/styles/profile/profileNotification';
 
@@ -71,6 +76,18 @@ const LEVEL_PRESETS: Record<NotificationLevel, Record<ItemKey, boolean>> = {
   urgent: { deadline: true, checklist: false, weekly: false, document: false },
 };
 
+const prefToLevel = (pref: NotificationPreference): NotificationLevel => {
+  if (pref === 'ALL') return 'all';
+  if (pref === 'URGENT_ONLY') return 'urgent';
+  return 'important';
+};
+
+const levelToPref = (lv: NotificationLevel): NotificationPreference => {
+  if (lv === 'all') return 'ALL';
+  if (lv === 'urgent') return 'URGENT_ONLY';
+  return 'IMPORTANT';
+};
+
 const ProfileNotificationScreen = () => {
   const { t } = useTranslation();
   const [masterOn, setMasterOn] = useState(true);
@@ -82,6 +99,31 @@ const ProfileNotificationScreen = () => {
     document: false,
   });
 
+  useEffect(() => {
+    fetchMyInfo()
+      .then((user) => {
+        const pref = user.notificationPreference as NotificationPreference;
+        if (pref === 'OFF') {
+          setMasterOn(false);
+        } else {
+          const lv = prefToLevel(pref);
+          setMasterOn(true);
+          setLevel(lv);
+          setItems(LEVEL_PRESETS[lv]);
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleMasterToggle = async (value: boolean) => {
+    setMasterOn(value);
+    if (!value) {
+      await updateNotificationPreference('OFF').catch(() => setMasterOn(true));
+    } else {
+      await updateNotificationPreference(levelToPref(level)).catch(() => setMasterOn(false));
+    }
+  };
+
   const handleItemToggle = (key: ItemKey) => {
     const newItems = { ...items, [key]: !items[key] };
     setItems(newItems);
@@ -91,9 +133,10 @@ const ProfileNotificationScreen = () => {
     if (matched) setLevel(matched[0] as NotificationLevel);
   };
 
-  const handleLevelChange = (newLevel: NotificationLevel) => {
+  const handleLevelChange = async (newLevel: NotificationLevel) => {
     setLevel(newLevel);
     setItems(LEVEL_PRESETS[newLevel]);
+    await updateNotificationPreference(levelToPref(newLevel)).catch(() => {});
   };
 
   return (
@@ -112,7 +155,7 @@ const ProfileNotificationScreen = () => {
             <Text style={styles.masterTitle}>{t('profile.notificationSetting.masterTitle')}</Text>
             <Text style={styles.masterDesc}>{t('profile.notificationSetting.masterDesc')}</Text>
           </View>
-          <Toggle value={masterOn} onValueChange={setMasterOn} />
+          <Toggle value={masterOn} onValueChange={handleMasterToggle} />
         </View>
 
         {/* 알림 단계 */}

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -36,7 +36,9 @@ export interface UserInfo {
   email: string;
   name: string;
   languageCode: string;
+  phoneNumber: string;
   notificationEnabled: boolean;
+  notificationPreference: string;
   createdAt: string;
 }
 

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -62,3 +62,16 @@ export const updateLanguage = async (languageCode: string): Promise<void> => {
     throw wrapError(error);
   }
 };
+
+export type NotificationPreference = 'ALL' | 'IMPORTANT' | 'URGENT_ONLY' | 'OFF';
+
+export const updateNotificationPreference = async (
+  notificationPreference: NotificationPreference
+): Promise<void> => {
+  try {
+    const headers = await getAuthHeader();
+    await apiClient.patch('/api/v1/users/me/notification', { notificationPreference }, { headers });
+  } catch (error) {
+    throw wrapError(error);
+  }
+};

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -2,20 +2,35 @@ import axios from 'axios';
 import * as SecureStore from 'expo-secure-store';
 import { apiClient } from './auth';
 
+export class UserApiError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string
+  ) {
+    super(message);
+    this.name = 'UserApiError';
+  }
+}
+
 const wrapError = (error: unknown): Error => {
   if (axios.isAxiosError(error) && error.response?.data?.code) {
-    return new Error(error.response.data.message ?? '알 수 없는 오류');
+    return new UserApiError(
+      error.response.data.code,
+      error.response.data.message ?? '알 수 없는 오류'
+    );
   }
   return error instanceof Error ? error : new Error(String(error));
 };
 
 const getAuthHeader = async () => {
   const token = await SecureStore.getItemAsync('accessToken');
-  if (!token) throw new Error('로그인이 필요합니다.');
+  if (!token) {
+    throw new UserApiError('UNAUTHORIZED', '로그인이 필요합니다.');
+  }
   return { Authorization: `Bearer ${token}` };
 };
 
-export interface UserProfile {
+export interface UserInfo {
   userId: number;
   loginId: string;
   email: string;
@@ -25,15 +40,17 @@ export interface UserProfile {
   createdAt: string;
 }
 
-export const getMe = async (): Promise<UserProfile> => {
+export const fetchMyInfo = async (): Promise<UserInfo> => {
   try {
     const headers = await getAuthHeader();
-    const response = await apiClient.get<{ result: UserProfile }>('/api/v1/users/me', { headers });
-    return response.data.result;
+    const { data } = await apiClient.get<{ result: UserInfo }>('/api/v1/users/me', { headers });
+    return data.result;
   } catch (error) {
     throw wrapError(error);
   }
 };
+
+export const getMe = async (): Promise<UserInfo> => fetchMyInfo();
 
 export const updateLanguage = async (languageCode: string): Promise<void> => {
   try {


### PR DESCRIPTION
## 📌 작업 내용

- 내 정보 조회 API 연동
- 알림 설정 변경 API 연동

## 📷 스크린 샷
<img width="300" src="https://github.com/user-attachments/assets/139212d7-4d91-4966-8c16-a3cd10996f2f" />
<img width="300" src="https://github.com/user-attachments/assets/a1d7e62d-d1a4-4f51-ac6f-165b0fbc6984" />

## ⚠️ 참고 사항

-

## 🔗 관련 이슈

Closes #62 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **개선사항**
  * 프로필 화면에서 실제 사용자 정보를 표시하도록 개선됨
  * 프로필 편집 화면의 사용자 정보(로그인ID, 이름, 전화번호, 이메일)가 현재 계정 데이터와 정확하게 동기화됨
  * 사용자 가입일 정보가 프로필에 추가되어 표시됨
  * 알림 설정이 사용자의 실제 환경설정에 따라 반영됨

<!-- end of auto-generated comment: release notes by coderabbit.ai -->