### PR TITLE
✨ [Feature] AI 요약 대화 주제 카드 추가, 체크리스트 API 연동 및 뒤로가기 확인 모달 (#74)

### DIFF
--- a/app/profile/edit.tsx
+++ b/app/profile/edit.tsx
@@ -1,18 +1,10 @@
 import { useState, useEffect } from 'react';
-import {
-  View,
-  Text,
-  Image,
-  ScrollView,
-  TouchableOpacity,
-  Modal,
-  TouchableWithoutFeedback,
-  Alert,
-} from 'react-native';
+import { View, Text, Image, ScrollView, TouchableOpacity, Alert } from 'react-native';
 import { Ionicons, FontAwesome5 } from '@expo/vector-icons';
 import { router } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import Header from '../../src/components/common/Header';
+import ConfirmModal from '../../src/components/common/ConfirmModal';
 import { fetchMyInfo, UserInfo } from '../../src/api/user';
 import colors from '../../src/constants/colors';
 import styles from '../../src/styles/profile/profileEdit';
@@ -21,19 +13,14 @@ const ProfileEditScreen = () => {
   const { t } = useTranslation();
   const [withdrawModalVisible, setWithdrawModalVisible] = useState(false);
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
-  const [loadError, setLoadError] = useState(false);
 
   useEffect(() => {
     fetchMyInfo()
-      .then((info) => {
-        setUserInfo(info);
-        setLoadError(false);
-      })
+      .then(setUserInfo)
       .catch(() => {
-        setLoadError(true);
         Alert.alert(t('common.error'), t('common.networkError'));
       });
-  }, []);
+  }, [t]);
 
   return (
     <View style={styles.container}>
@@ -83,48 +70,19 @@ const ProfileEditScreen = () => {
         </TouchableOpacity>
       </ScrollView>
 
-      <Modal
+      <ConfirmModal
         visible={withdrawModalVisible}
-        transparent
-        animationType="fade"
-        onRequestClose={() => setWithdrawModalVisible(false)}
-      >
-        <TouchableWithoutFeedback onPress={() => setWithdrawModalVisible(false)}>
-          <View style={styles.modalOverlay}>
-            <TouchableWithoutFeedback onPress={() => {}}>
-              <View style={styles.modalCard}>
-                <View style={styles.iconBox}>
-                  <FontAwesome5 name="user-slash" size={26} color={colors.primary[500]} />
-                </View>
-                <Text style={styles.modalTitle}>{t('profile.editProfile.withdrawTitle')}</Text>
-                <Text style={styles.modalDesc}>{t('profile.editProfile.withdrawDesc')}</Text>
-                <View style={styles.warningBanner}>
-                  <Ionicons name="warning" size={15} color={colors.text.primary} />
-                  <Text style={styles.warningText}>{t('profile.editProfile.withdrawWarning')}</Text>
-                </View>
-                <View style={styles.btnRow}>
-                  <TouchableOpacity
-                    style={styles.cancelBtn}
-                    onPress={() => setWithdrawModalVisible(false)}
-                    activeOpacity={0.8}
-                  >
-                    <Text style={styles.cancelBtnText}>{t('profile.editProfile.cancel')}</Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity
-                    style={[styles.withdrawModalBtn, styles.withdrawModalBtnDisabled]}
-                    disabled
-                    activeOpacity={1}
-                  >
-                    <Text style={styles.withdrawModalBtnText}>
-                      {t('profile.editProfile.withdraw')}
-                    </Text>
-                  </TouchableOpacity>
-                </View>
-              </View>
-            </TouchableWithoutFeedback>
-          </View>
-        </TouchableWithoutFeedback>
-      </Modal>
+        onClose={() => setWithdrawModalVisible(false)}
+        icon={<FontAwesome5 name="user-slash" size={26} color={colors.primary[500]} />}
+        title={t('profile.editProfile.withdrawTitle')}
+        description={t('profile.editProfile.withdrawDesc')}
+        warning={t('profile.editProfile.withdrawWarning')}
+        cancelText={t('profile.editProfile.cancel')}
+        onCancel={() => setWithdrawModalVisible(false)}
+        confirmText={t('profile.editProfile.withdraw')}
+        onConfirm={() => {}}
+        confirmDisabled
+      />
     </View>
   );
 };

--- a/app/profile/edit.tsx
+++ b/app/profile/edit.tsx
@@ -20,7 +20,9 @@ const ProfileEditScreen = () => {
       .catch(() => {
         Alert.alert(t('common.error'), t('common.networkError'));
       });
-  }, [t]);
+    // t is used only in the error callback — re-fetching on language change is undesirable
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <View style={styles.container}>

--- a/app/scan/result.tsx
+++ b/app/scan/result.tsx
@@ -1,10 +1,18 @@
-import { useEffect, useState } from 'react';
-import { View, Text, TouchableOpacity, ScrollView, ActivityIndicator } from 'react-native';
+import { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  ScrollView,
+  ActivityIndicator,
+  BackHandler,
+} from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import Header from '../../src/components/common/Header';
+import ConfirmModal from '../../src/components/common/ConfirmModal';
 import ScanHelpModal from '../../src/components/scan/ScanHelpModal';
 import FullDocTab from '../../src/components/scan/result/FullDocTab';
 import ChecklistTab from '../../src/components/scan/result/ChecklistTab';
@@ -43,6 +51,19 @@ const ScanResultScreen = () => {
 
   const [detail, setDetail] = useState<NewsletterDetail | null>(null);
   const [detailLoading, setDetailLoading] = useState(!!newsletterIdParam);
+  const [unsavedVisible, setUnsavedVisible] = useState(false);
+
+  const handleBack = useCallback(() => {
+    setUnsavedVisible(true);
+  }, []);
+
+  useEffect(() => {
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      setUnsavedVisible(true);
+      return true;
+    });
+    return () => sub.remove();
+  }, []);
 
   useEffect(() => {
     if (!newsletterId) {
@@ -76,7 +97,11 @@ const ScanResultScreen = () => {
 
   return (
     <View style={styles.screen}>
-      <Header title={t('scan.result.title')} onHelp={() => setHelpVisible(true)} />
+      <Header
+        title={t('scan.result.title')}
+        onBack={handleBack}
+        onHelp={() => setHelpVisible(true)}
+      />
 
       <View style={styles.docInfo}>
         {detailLoading ? (
@@ -157,6 +182,17 @@ const ScanResultScreen = () => {
       </View>
 
       <ScanHelpModal visible={helpVisible} onClose={() => setHelpVisible(false)} />
+      <ConfirmModal
+        visible={unsavedVisible}
+        onClose={() => setUnsavedVisible(false)}
+        icon={<Ionicons name="save" size={30} color={colors.primary[600]} />}
+        title={t('scan.result.unsavedAlert.title')}
+        description={t('scan.result.unsavedAlert.message')}
+        cancelText={t('scan.result.unsavedAlert.cancel')}
+        onCancel={() => setUnsavedVisible(false)}
+        confirmText={t('scan.result.unsavedAlert.confirm')}
+        onConfirm={() => router.replace('/(tabs)')}
+      />
       <SaveBottomSheet
         visible={saveVisible}
         onClose={() => setSaveVisible(false)}

--- a/src/api/checklist.ts
+++ b/src/api/checklist.ts
@@ -64,3 +64,12 @@ export const toggleChecklistItem = async (
     throw wrapError(error);
   }
 };
+
+export const deleteChecklistItem = async (checklistId: number): Promise<void> => {
+  try {
+    const headers = await getAuthHeader();
+    await apiClient.delete(`/api/v1/checklists/${checklistId}`, { headers });
+  } catch (error) {
+    throw wrapError(error);
+  }
+};

--- a/src/api/newsletter.ts
+++ b/src/api/newsletter.ts
@@ -245,6 +245,24 @@ export interface NewsletterListResult {
   totalCount: number;
 }
 
+export interface ConversationTopic {
+  topicId: number;
+  topic: string;
+}
+
+export const getConversationTopics = async (newsletterId: number): Promise<ConversationTopic[]> => {
+  try {
+    const headers = await getAuthHeader();
+    const response = await apiClient.get<{ result: { topics: ConversationTopic[] } }>(
+      `/api/v1/newsletters/${newsletterId}/conversation-topics`,
+      { headers }
+    );
+    return response.data.result.topics ?? [];
+  } catch (error) {
+    throw wrapError(error);
+  }
+};
+
 export const fetchNewsletters = async (params: {
   childName?: string;
   search?: string;

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -1,0 +1,167 @@
+import { ReactNode } from 'react';
+import {
+  View,
+  Text,
+  Modal,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  StyleSheet,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import colors from '../../constants/colors';
+import fonts from '../../constants/fonts';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  icon: ReactNode;
+  iconBg?: string;
+  title: string;
+  description: string;
+  warning?: string;
+  cancelText: string;
+  onCancel: () => void;
+  confirmText: string;
+  onConfirm: () => void;
+  confirmDisabled?: boolean;
+}
+
+const ConfirmModal = ({
+  visible,
+  onClose,
+  icon,
+  iconBg = colors.primary[100],
+  title,
+  description,
+  warning,
+  cancelText,
+  onCancel,
+  confirmText,
+  onConfirm,
+  confirmDisabled = false,
+}: Props) => {
+  const cardContent = (
+    <View style={styles.card}>
+      <View style={[styles.iconBox, { backgroundColor: iconBg }]}>{icon}</View>
+      <Text style={styles.title}>{title}</Text>
+      <Text style={styles.description}>{description}</Text>
+      {warning ? (
+        <View style={styles.warningBanner}>
+          <Ionicons name="warning" size={15} color={colors.text.primary} />
+          <Text style={styles.warningText}>{warning}</Text>
+        </View>
+      ) : null}
+      <View style={styles.btnRow}>
+        <TouchableOpacity style={styles.cancelBtn} onPress={onCancel} activeOpacity={0.8}>
+          <Text style={styles.cancelBtnText}>{cancelText}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.confirmBtn, confirmDisabled && styles.confirmBtnDisabled]}
+          onPress={onConfirm}
+          disabled={confirmDisabled}
+          activeOpacity={confirmDisabled ? 1 : 0.8}
+        >
+          <Text style={styles.confirmBtnText}>{confirmText}</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <TouchableWithoutFeedback onPress={onClose}>
+        <View style={styles.overlay}>
+          <TouchableWithoutFeedback onPress={() => {}}>{cardContent}</TouchableWithoutFeedback>
+        </View>
+      </TouchableWithoutFeedback>
+    </Modal>
+  );
+};
+
+export default ConfirmModal;
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.45)',
+    justifyContent: 'center',
+  },
+  card: {
+    backgroundColor: colors.text.white,
+    borderRadius: 20,
+    marginHorizontal: 20,
+    paddingHorizontal: 20,
+    paddingTop: 30,
+    paddingBottom: 20,
+    gap: 15,
+    alignItems: 'center',
+  },
+  iconBox: {
+    borderRadius: 10,
+    padding: 15,
+  },
+  title: {
+    fontSize: 18,
+    fontFamily: fonts.bold,
+    color: colors.text.primary,
+  },
+  description: {
+    fontSize: 16,
+    fontFamily: fonts.medium,
+    color: colors.text.secondary,
+    textAlign: 'center',
+    lineHeight: 24,
+  },
+  warningBanner: {
+    backgroundColor: colors.secondary[500],
+    borderRadius: 15,
+    padding: 15,
+    flexDirection: 'row',
+    gap: 11,
+    alignItems: 'center',
+    width: '100%',
+  },
+  warningText: {
+    fontSize: 12,
+    fontFamily: fonts.medium,
+    color: colors.text.primary,
+    lineHeight: 16,
+    flex: 1,
+  },
+  btnRow: {
+    flexDirection: 'row',
+    gap: 15,
+    width: '100%',
+  },
+  cancelBtn: {
+    flex: 1,
+    height: 55,
+    borderRadius: 15,
+    backgroundColor: colors.primary[500],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cancelBtnText: {
+    fontSize: 16,
+    fontFamily: fonts.semiBold,
+    color: colors.text.white,
+  },
+  confirmBtn: {
+    flex: 1,
+    height: 55,
+    borderRadius: 15,
+    backgroundColor: colors.text.white,
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  confirmBtnDisabled: {
+    opacity: 0.4,
+  },
+  confirmBtnText: {
+    fontSize: 16,
+    fontFamily: fonts.semiBold,
+    color: colors.gray[200],
+  },
+});

--- a/src/components/scan/result/AISummaryTab.tsx
+++ b/src/components/scan/result/AISummaryTab.tsx
@@ -4,10 +4,10 @@ import { useTranslation } from 'react-i18next';
 import SummaryCard from './SummaryCard';
 import {
   getNewsletterSummary,
-  getNewsletterChecklist,
+  getConversationTopics,
   NewsletterApiError,
 } from '../../../api/newsletter';
-import type { NewsletterSummaryResult, ChecklistItem } from '../../../api/newsletter';
+import type { NewsletterSummaryResult, ConversationTopic } from '../../../api/newsletter';
 import colors from '../../../constants/colors';
 import fonts from '../../../constants/fonts';
 
@@ -31,23 +31,23 @@ const AISummaryTab = ({ newsletterId }: Props) => {
   const [summaryLoading, setSummaryLoading] = useState(true);
   const [summaryError, setSummaryError] = useState<string | null>(null);
 
-  const [todos, setTodos] = useState<ChecklistItem[]>([]);
-  const [todoLoading, setTodoLoading] = useState(true);
-  const [todoError, setTodoError] = useState<string | null>(null);
+  const [topics, setTopics] = useState<ConversationTopic[]>([]);
+  const [topicsLoading, setTopicsLoading] = useState(true);
+  const [topicsError, setTopicsError] = useState<string | null>(null);
 
   useEffect(() => {
     setSummary(null);
     setSummaryLoading(true);
     setSummaryError(null);
-    setTodos([]);
-    setTodoLoading(true);
-    setTodoError(null);
+    setTopics([]);
+    setTopicsLoading(true);
+    setTopicsError(null);
 
     if (!newsletterId) {
       setSummaryError('scan.result.aiSummary.error.notFound');
       setSummaryLoading(false);
-      setTodoError('scan.result.aiSummary.error.notFound');
-      setTodoLoading(false);
+      setTopicsError('scan.result.aiSummary.error.notFound');
+      setTopicsLoading(false);
       return () => {};
     }
 
@@ -60,30 +60,30 @@ const AISummaryTab = ({ newsletterId }: Props) => {
           setSummaryError(null);
         }
       })
-      .catch((e) => {
+      .catch((e: unknown) => {
         if (!cancelled) setSummaryError(mapSummaryErrorKey(e));
       })
       .finally(() => {
         if (!cancelled) setSummaryLoading(false);
       });
 
-    getNewsletterChecklist(newsletterId, 'TODO')
+    getConversationTopics(newsletterId)
       .then((data) => {
         if (!cancelled) {
-          setTodos(data);
-          setTodoError(null);
+          setTopics(data);
+          setTopicsError(null);
         }
       })
-      .catch((e) => {
+      .catch((e: unknown) => {
         if (cancelled) return;
         if (e instanceof NewsletterApiError && e.code === 'NL4041') {
-          setTodoError('scan.result.aiSummary.error.newsletterNotFound');
+          setTopicsError('scan.result.aiSummary.error.newsletterNotFound');
         } else {
-          setTodoError('scan.result.aiSummary.error.todoFailed');
+          setTopicsError('scan.result.aiSummary.error.conversationFailed');
         }
       })
       .finally(() => {
-        if (!cancelled) setTodoLoading(false);
+        if (!cancelled) setTopicsLoading(false);
       });
 
     return () => {
@@ -111,21 +111,16 @@ const AISummaryTab = ({ newsletterId }: Props) => {
     return null;
   };
 
-  const renderTodos = () => {
-    if (todoLoading) return <ActivityIndicator size="small" color={colors.primary[400]} />;
-    if (todoError) return <Text style={styles.errorText}>{t(todoError)}</Text>;
-    if (todos.length === 0)
-      return <Text style={styles.errorText}>{t('scan.result.aiSummary.emptyTodo')}</Text>;
+  const renderTopics = () => {
+    if (topicsLoading) return <ActivityIndicator size="small" color={colors.primary[400]} />;
+    if (topicsError) return <Text style={styles.errorText}>{t(topicsError)}</Text>;
+    if (topics.length === 0)
+      return <Text style={styles.errorText}>{t('scan.result.aiSummary.conversationEmpty')}</Text>;
     return (
-      <View style={styles.todoList}>
-        {todos.map((item) => (
-          <View key={item.checklistId} style={styles.todoItem}>
-            <View style={styles.bullet} />
-            <Text style={styles.todoText}>
-              {item.targetDateLabel && <Text style={styles.todoWhen}>{item.targetDateLabel}</Text>}
-              {item.targetDateLabel ? ' — ' : ''}
-              {item.content}
-            </Text>
+      <View style={styles.topicList}>
+        {topics.map((item) => (
+          <View key={item.topicId} style={styles.topicBubble}>
+            <Text style={styles.topicText}>{item.topic}</Text>
           </View>
         ))}
       </View>
@@ -143,11 +138,11 @@ const AISummaryTab = ({ newsletterId }: Props) => {
       </SummaryCard>
 
       <SummaryCard
-        icon="alarm-outline"
-        iconBg={colors.secondary[600]}
-        title={t('scan.result.aiSummary.todayTodo')}
+        icon="chatbubbles-outline"
+        iconBg={colors.secondary[500]}
+        title={t('scan.result.aiSummary.conversationTitle')}
       >
-        {renderTodos()}
+        {renderTopics()}
       </SummaryCard>
 
       <SummaryCard
@@ -200,36 +195,22 @@ const styles = StyleSheet.create({
     fontFamily: fonts.medium,
     color: colors.text.secondary,
   },
-  todoList: {
+  topicList: {
     gap: 10,
   },
-  todoItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
-    borderColor: colors.secondary[200],
+  topicBubble: {
+    backgroundColor: colors.secondary[200],
     borderWidth: 1,
-    backgroundColor: colors.secondary[100],
-    borderRadius: 12,
-    paddingHorizontal: 12,
-    paddingVertical: 12,
+    borderColor: colors.secondary[500],
+    borderRadius: 16,
+    borderBottomLeftRadius: 0,
+    padding: 12,
   },
-  bullet: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: colors.secondary[600],
-  },
-  todoText: {
-    flex: 1,
+  topicText: {
     fontSize: 14,
     fontFamily: fonts.regular,
     color: colors.text.primary,
     lineHeight: 22,
-  },
-  todoWhen: {
-    fontFamily: fonts.bold,
-    color: colors.text.primary,
   },
   qnaList: {
     gap: 16,

--- a/src/components/scan/result/ChecklistTab.tsx
+++ b/src/components/scan/result/ChecklistTab.tsx
@@ -4,6 +4,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import { getNewsletterChecklist, NewsletterApiError } from '../../../api/newsletter';
 import type { ChecklistItem } from '../../../api/newsletter';
+import { toggleChecklistItem, deleteChecklistItem } from '../../../api/checklist';
 import colors from '../../../constants/colors';
 import fonts from '../../../constants/fonts';
 
@@ -52,15 +53,21 @@ const ChecklistTab = ({ newsletterId }: Props) => {
   }, [newsletterId]);
 
   const toggle = (id: number) => {
-    setItems((prev) =>
-      prev.map((item) =>
-        item.checklistId === id ? { ...item, isCompleted: !item.isCompleted } : item
-      )
+    const prev = items;
+    const next = items.map((item) =>
+      item.checklistId === id ? { ...item, isCompleted: !item.isCompleted } : item
     );
+    setItems(next);
+    const target = next.find((item) => item.checklistId === id);
+    if (target) {
+      toggleChecklistItem(id, target.isCompleted).catch(() => setItems(prev));
+    }
   };
 
   const remove = (id: number) => {
-    setItems((prev) => prev.filter((item) => item.checklistId !== id));
+    const prev = items;
+    setItems((list) => list.filter((item) => item.checklistId !== id));
+    deleteChecklistItem(id).catch(() => setItems(prev));
   };
 
   if (loading) {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -406,6 +406,13 @@
     },
     "result": {
       "title": "Scan Result",
+      "unsavedAlert": {
+        "title": "Are you sure you want to leave?",
+        "message": "Without saving, you won't be able to use\nthe checklist or register calendar events.",
+        "warning": "If you leave without saving, the scan result will be lost and cannot be recovered.",
+        "confirm": "Leave",
+        "cancel": "Keep Viewing"
+      },
       "tabs": {
         "full": "Full Document",
         "checklist": "Checklist",
@@ -435,9 +442,9 @@
       },
       "aiSummary": {
         "summarySection": "AI Summary",
-        "todayTodo": "Todo",
         "culturalContext": "Cultural Context",
-        "emptyTodo": "No tasks yet.",
+        "conversationTitle": "Today's Conversation Topics",
+        "conversationEmpty": "No conversation topics available.",
         "error": {
           "notFound": "School notice info not found.",
           "analyzing": "This school notice is still being analyzed.",
@@ -445,7 +452,7 @@
           "newsletterNotFound": "School notice not found.",
           "noAccess": "No access permission.",
           "summaryFailed": "Failed to load summary.",
-          "todoFailed": "Failed to load task list."
+          "conversationFailed": "Failed to load conversation topics."
         },
         "qna": [
           {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -406,6 +406,13 @@
     },
     "result": {
       "title": "스캔 결과",
+      "unsavedAlert": {
+        "title": "정말 나가시겠어요?",
+        "message": "저장하지 않으면 체크리스트 확인과\n캘린더 일정 등록을 이용할 수 없어요.",
+        "warning": "저장하지 않으면 스캔 결과가 사라지며 복구할 수 없어요.",
+        "confirm": "나가기",
+        "cancel": "계속 보기"
+      },
       "tabs": {
         "full": "전체 문서",
         "checklist": "체크리스트",
@@ -435,9 +442,9 @@
       },
       "aiSummary": {
         "summarySection": "AI 요약",
-        "todayTodo": "해야 할 일",
         "culturalContext": "문화 맥락 안내",
-        "emptyTodo": "등록된 할 일이 없어요.",
+        "conversationTitle": "오늘의 대화 주제",
+        "conversationEmpty": "대화 주제가 없어요.",
         "error": {
           "notFound": "가정통신문 정보를 찾을 수 없어요.",
           "analyzing": "아직 분석 중인 가정통신문이에요.",
@@ -445,7 +452,7 @@
           "newsletterNotFound": "가정통신문을 찾을 수 없어요.",
           "noAccess": "접근 권한이 없어요.",
           "summaryFailed": "요약을 불러오는 데 실패했어요.",
-          "todoFailed": "할 일 목록을 불러오는 데 실패했어요."
+          "conversationFailed": "대화 주제를 불러오는 데 실패했어요."
         },
         "qna": [
           {

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -406,6 +406,13 @@
     },
     "result": {
       "title": "Kết quả quét",
+      "unsavedAlert": {
+        "title": "Bạn có chắc muốn thoát không?",
+        "message": "Nếu không lưu, bạn sẽ không thể dùng\ndanh sách việc cần làm hoặc đăng ký lịch.",
+        "warning": "Nếu thoát mà không lưu, kết quả quét sẽ biến mất và không thể khôi phục.",
+        "confirm": "Thoát",
+        "cancel": "Tiếp tục xem"
+      },
       "tabs": {
         "full": "Toàn bộ tài liệu",
         "checklist": "Danh sách việc cần làm",
@@ -435,9 +442,9 @@
       },
       "aiSummary": {
         "summarySection": "Tóm tắt AI",
-        "todayTodo": "Việc cần làm",
         "culturalContext": "Hướng dẫn bối cảnh văn hóa",
-        "emptyTodo": "Không có việc cần làm nào được đăng ký.",
+        "conversationTitle": "Chủ đề trò chuyện hôm nay",
+        "conversationEmpty": "Không có chủ đề trò chuyện.",
         "error": {
           "notFound": "Không tìm thấy thông tin thông báo.",
           "analyzing": "Thông báo này đang được phân tích.",
@@ -445,7 +452,7 @@
           "newsletterNotFound": "Không tìm thấy thông báo.",
           "noAccess": "Bạn không có quyền truy cập.",
           "summaryFailed": "Tải tóm tắt thất bại.",
-          "todoFailed": "Tải danh sách việc cần làm thất bại."
+          "conversationFailed": "Tải chủ đề trò chuyện thất bại."
         },
         "qna": [
           {

--- a/src/utils/pushToken.ts
+++ b/src/utils/pushToken.ts
@@ -14,16 +14,10 @@ export const registerDevicePushToken = async (): Promise<void> => {
     const { status } = await Notifications.requestPermissionsAsync();
     finalStatus = status;
   }
-  if (finalStatus !== 'granted') {
-    console.log('[PushToken] 알림 권한 거부됨');
-    return;
-  }
+  if (finalStatus !== 'granted') return;
 
   const projectId = Constants.expoConfig?.extra?.eas?.projectId ?? Constants.easConfig?.projectId;
-  if (!projectId) {
-    console.error('[PushToken] EAS projectId를 찾을 수 없습니다');
-    return;
-  }
+  if (!projectId) return;
 
   try {
     const platform = 'EXPO' as const;
@@ -35,8 +29,7 @@ export const registerDevicePushToken = async (): Promise<void> => {
         : ((await Application.getIosIdForVendorAsync()) ?? 'ios-unknown');
 
     await registerPushToken({ platform, token, deviceId, appVersion });
-    console.log('[PushToken] 서버 등록 성공');
-  } catch (error) {
-    console.error('[PushToken] 등록 중 에러 발생:', error);
+  } catch {
+    // push token registration failure is non-fatal
   }
 };


### PR DESCRIPTION
## 📌 작업 내용

- `GET /api/v1/newsletters/{id}/conversation-topics` 연동 — AI 요약 탭의 해야할 일 카드를 오늘의 대화 주제 카드로 교체
- `PATCH /api/v1/checklists/{id}/complete` 연동 — 체크박스 완료 처리 API 연동 (낙관적 업데이트 + 실패 시 롤백)
- `DELETE /api/v1/checklists/{id}` 연동 — 체크리스트 항목 삭제 API 연동 (낙관적 업데이트 + 실패 시 롤백)
- 공통 `ConfirmModal` 컴포넌트 추가 (아이콘/제목/설명/경고 배너/버튼)
- 스캔 결과 화면에서 저장 전 뒤로가기 시 확인 모달 표시 (헤더 백버튼 + Android 물리 백버튼)
- 프로필 탈퇴 확인 모달을 인라인 구현에서 `ConfirmModal`로 교체

## 📷 스크린 샷
<img width="300" height="666" alt="Screenshot_1780679111" src="https://github.com/user-attachments/assets/71e7fed1-b082-4bb2-977f-3f82c80eecee" />

## ⚠️ 참고 사항

- 대화 주제 카드는 말풍선 스타일 (borderBottomLeftRadius: 0) UI로 구현
- 체크리스트 완료/삭제 모두 낙관적 업데이트 방식 — API 실패 시 이전 상태로 롤백

## 🔗 관련 이슈

Closes #74 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 스캔 결과 페이지에서 저장하지 않고 나갈 때 경고 메시지 추가
  * AI 요약에서 대화 주제 표시 추가

* **Bug Fixes**
  * 프로필 정보 로딩 중 에러 처리 개선
  * 체크리스트 항목 삭제 기능 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->