### PR TITLE
✨ [Feature] 급식·시간표 위젯 및 전체보기 페이지 구현 (#82)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -12,6 +12,7 @@ import { useNotificationStore } from '../../src/store/notificationStore';
 import TaskCard from '../../src/components/home/TaskCard';
 import ScanBanner from '../../src/components/home/ScanBanner';
 import FeatureSection from '../../src/components/home/FeatureSection';
+import MealTimetableWidget from '../../src/components/home/MealTimetableWidget';
 import GuideCards from '../../src/components/home/GuideCards';
 import RecentDocs from '../../src/components/home/RecentDocs';
 import colors from '../../src/constants/colors';
@@ -81,6 +82,7 @@ const HomeScreen = () => {
           <TaskCard />
           <ScanBanner />
           <FeatureSection />
+          <MealTimetableWidget />
           <GuideCards />
           <RecentDocs />
         </ScrollView>

--- a/app/meal-timetable/index.tsx
+++ b/app/meal-timetable/index.tsx
@@ -1,0 +1,317 @@
+import { useState, useEffect, useMemo } from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+  useWindowDimensions,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useChildrenStore } from '../../src/store/childrenStore';
+import {
+  fetchSchoolMeals,
+  getMealsForChild,
+  fetchSchoolTimetables,
+  getPeriodsForChild,
+  SchoolMealGroup,
+  SchoolTimetableGroup,
+} from '../../src/api/meal';
+import Header from '../../src/components/common/Header';
+import colors from '../../src/constants/colors';
+import layout from '../../src/constants/layout';
+import styles from '../../src/styles/meal-timetable';
+
+const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
+const PERIOD_COL_W = 40;
+
+const fmt = (d: Date): string => {
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${d.getFullYear()}-${m}-${day}`;
+};
+
+const isToday = (d: Date): boolean => {
+  const t = new Date();
+  return (
+    d.getFullYear() === t.getFullYear() &&
+    d.getMonth() === t.getMonth() &&
+    d.getDate() === t.getDate()
+  );
+};
+
+const getDisplayWeekDays = (): Date[] => {
+  const today = new Date();
+  const dow = today.getDay();
+  const monday = new Date(today);
+  if (dow === 0) monday.setDate(today.getDate() + 1);
+  else if (dow === 6) monday.setDate(today.getDate() + 2);
+  else monday.setDate(today.getDate() - (dow - 1));
+  monday.setHours(0, 0, 0, 0);
+  return Array.from({ length: 5 }, (_, i) => {
+    const d = new Date(monday);
+    d.setDate(monday.getDate() + i);
+    return d;
+  });
+};
+
+const getNextWeekdays = (count: number): Date[] => {
+  const result: Date[] = [];
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  while (result.length < count) {
+    if (d.getDay() !== 0 && d.getDay() !== 6) result.push(new Date(d));
+    d.setDate(d.getDate() + 1);
+  }
+  return result;
+};
+
+const MealTimetablePage = () => {
+  const insets = useSafeAreaInsets();
+  const { width: screenWidth } = useWindowDimensions();
+  const childItems = useChildrenStore((s) => s.children);
+
+  const [selectedChildIdx, setSelectedChildIdx] = useState(0);
+  const [activeTab, setActiveTab] = useState<'timetable' | 'meal'>('timetable');
+  const [schoolTimetables, setSchoolTimetables] = useState<SchoolTimetableGroup[]>([]);
+  const [schoolMeals, setSchoolMeals] = useState<SchoolMealGroup[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const weekDays = useMemo(() => getDisplayWeekDays(), []);
+  const mealDays = useMemo(() => getNextWeekdays(5), []);
+  const dayColW = (screenWidth - layout.screenPaddingHorizontal * 2 - PERIOD_COL_W) / 5;
+
+  const selectedChild = childItems[selectedChildIdx];
+
+  useEffect(() => {
+    if (!childItems.length) return;
+    setLoading(true);
+    const ttFrom = fmt(weekDays[0]);
+    const ttTo = fmt(weekDays[4]);
+    const mealFrom = fmt(mealDays[0]);
+    const mealTo = fmt(mealDays[mealDays.length - 1]);
+    Promise.all([
+      fetchSchoolTimetables(ttFrom, ttTo).catch(() => [] as SchoolTimetableGroup[]),
+      fetchSchoolMeals(mealFrom, mealTo).catch(() => [] as SchoolMealGroup[]),
+    ])
+      .then(([tt, meals]) => {
+        setSchoolTimetables(tt);
+        setSchoolMeals(meals);
+      })
+      .finally(() => setLoading(false));
+  }, [childItems, weekDays, mealDays]);
+
+  const timetableByDay = useMemo(() => {
+    if (!selectedChild) return [];
+    return weekDays.map((d) => ({
+      date: d,
+      periods: getPeriodsForChild(
+        schoolTimetables,
+        selectedChild.officeCode,
+        selectedChild.schoolCode,
+        selectedChild.grade,
+        fmt(d)
+      ),
+    }));
+  }, [schoolTimetables, selectedChild, weekDays]);
+
+  const mealsByDay = useMemo(() => {
+    if (!selectedChild) return [];
+    return mealDays.map((d) => ({
+      date: d,
+      menus: getMealsForChild(
+        schoolMeals,
+        selectedChild.officeCode,
+        selectedChild.schoolCode,
+        fmt(d)
+      ),
+    }));
+  }, [schoolMeals, selectedChild, mealDays]);
+
+  const periodCount = useMemo(() => {
+    const allPeriods = timetableByDay.flatMap((d) => d.periods.map((p) => p.period));
+    return Math.max(0, ...allPeriods, 6);
+  }, [timetableByDay]);
+
+  const renderTimetable = () => {
+    if (loading) {
+      return (
+        <View style={styles.loadingWrap}>
+          <ActivityIndicator color={colors.primary[400]} />
+        </View>
+      );
+    }
+    return (
+      <View style={styles.tableWrap}>
+        <View style={styles.tableHeaderRow}>
+          <View style={[styles.tablePeriodCell, { width: PERIOD_COL_W }]} />
+          {timetableByDay.map((day) => (
+            <View
+              key={fmt(day.date)}
+              style={[
+                styles.tableDayHeader,
+                { width: dayColW },
+                isToday(day.date) && styles.todayHeaderCol,
+              ]}
+            >
+              <Text style={[styles.tableDayDate, isToday(day.date) && styles.todayText]}>
+                {day.date.getMonth() + 1}/{day.date.getDate()}
+              </Text>
+              <Text style={[styles.tableDayName, isToday(day.date) && styles.todayText]}>
+                {DAY_LABELS[day.date.getDay()]}
+              </Text>
+            </View>
+          ))}
+        </View>
+
+        {Array.from({ length: periodCount }, (_, i) => i + 1).map((period) => (
+          <View key={period} style={[styles.tableRow, period % 2 === 0 && styles.tableRowEven]}>
+            <View style={[styles.tablePeriodCell, { width: PERIOD_COL_W }]}>
+              <Text style={styles.tablePeriodText}>{period}</Text>
+            </View>
+            {timetableByDay.map((day) => {
+              const p = day.periods.find((pp) => pp.period === period);
+              return (
+                <View
+                  key={fmt(day.date)}
+                  style={[
+                    styles.tableCell,
+                    { width: dayColW },
+                    isToday(day.date) && styles.todayCell,
+                  ]}
+                >
+                  <Text style={styles.tableCellText} numberOfLines={2}>
+                    {p?.subject ?? ''}
+                  </Text>
+                </View>
+              );
+            })}
+          </View>
+        ))}
+      </View>
+    );
+  };
+
+  const renderMeals = () => {
+    if (loading) {
+      return (
+        <View style={styles.loadingWrap}>
+          <ActivityIndicator color={colors.primary[400]} />
+        </View>
+      );
+    }
+    return (
+      <View style={styles.timeline}>
+        {mealsByDay.map((day, i) => (
+          <View key={fmt(day.date)} style={styles.timelineItem}>
+            <View style={styles.timelineLeft}>
+              <View style={[styles.timelineDot, isToday(day.date) && styles.timelineDotActive]} />
+              {i < mealsByDay.length - 1 && <View style={styles.timelineLine} />}
+            </View>
+            <View style={styles.timelineRight}>
+              <View style={styles.timelineDateRow}>
+                <Text
+                  style={[
+                    styles.timelineDateText,
+                    isToday(day.date) && styles.timelineDateTextToday,
+                  ]}
+                >
+                  {day.date.getMonth() + 1}.{day.date.getDate()}.{DAY_LABELS[day.date.getDay()]},
+                  중식
+                </Text>
+                {isToday(day.date) && (
+                  <View style={styles.todayBadge}>
+                    <Text style={styles.todayBadgeText}>오늘</Text>
+                  </View>
+                )}
+              </View>
+              <View style={styles.mealCard}>
+                {day.menus.length > 0 ? (
+                  day.menus.map((menu) => (
+                    <View key={menu.name} style={styles.mealItem}>
+                      <View style={styles.mealBullet} />
+                      <Text style={styles.mealName}>
+                        {menu.name}
+                        {menu.allergyNums.length > 0 && (
+                          <Text style={styles.mealAllergyText}>
+                            {' '}
+                            ({menu.allergyNums.join('.')})
+                          </Text>
+                        )}
+                      </Text>
+                    </View>
+                  ))
+                ) : (
+                  <Text style={styles.noMealText}>급식 정보가 없어요</Text>
+                )}
+              </View>
+            </View>
+          </View>
+        ))}
+      </View>
+    );
+  };
+
+  return (
+    <View style={[styles.screen, { paddingTop: insets.top }]}>
+      <Header title="급식·시간표" />
+
+      {childItems.length > 1 && (
+        <View style={styles.childTabsWrap}>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.childTabs}
+          >
+            {childItems.map((child, i) => (
+              <TouchableOpacity
+                key={child.id}
+                style={[styles.childTab, i === selectedChildIdx && styles.childTabActive]}
+                onPress={() => setSelectedChildIdx(i)}
+                activeOpacity={0.8}
+              >
+                <View style={[styles.childTabDot, { backgroundColor: child.colorCode }]} />
+                <Text
+                  style={[styles.childTabText, i === selectedChildIdx && styles.childTabTextActive]}
+                >
+                  {child.name}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </ScrollView>
+        </View>
+      )}
+
+      <View style={styles.tabBar}>
+        <TouchableOpacity
+          style={[styles.tabItem, activeTab === 'timetable' && styles.tabItemActive]}
+          onPress={() => setActiveTab('timetable')}
+          activeOpacity={0.8}
+        >
+          <Text style={[styles.tabText, activeTab === 'timetable' && styles.tabTextActive]}>
+            시간표
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.tabItem, activeTab === 'meal' && styles.tabItemActive]}
+          onPress={() => setActiveTab('meal')}
+          activeOpacity={0.8}
+        >
+          <Text style={[styles.tabText, activeTab === 'meal' && styles.tabTextActive]}>급식</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.contentArea}>
+        <ScrollView
+          style={styles.content}
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator={false}
+        >
+          {activeTab === 'timetable' ? renderTimetable() : renderMeals()}
+        </ScrollView>
+      </View>
+    </View>
+  );
+};
+
+export default MealTimetablePage;

--- a/app/meal-timetable/index.tsx
+++ b/app/meal-timetable/index.tsx
@@ -77,6 +77,14 @@ const MealTimetablePage = () => {
   const [schoolMeals, setSchoolMeals] = useState<SchoolMealGroup[]>([]);
   const [loading, setLoading] = useState(false);
 
+  useEffect(() => {
+    if (!childItems.length) {
+      setSelectedChildIdx(0);
+      return;
+    }
+    setSelectedChildIdx((prev) => Math.min(prev, childItems.length - 1));
+  }, [childItems]);
+
   const weekDays = useMemo(() => getDisplayWeekDays(), []);
   const mealDays = useMemo(() => getNextWeekdays(5), []);
   const dayColW = (screenWidth - layout.screenPaddingHorizontal * 2 - PERIOD_COL_W) / 5;
@@ -228,7 +236,7 @@ const MealTimetablePage = () => {
               <View style={styles.mealCard}>
                 {day.menus.length > 0 ? (
                   day.menus.map((menu) => (
-                    <View key={menu.name} style={styles.mealItem}>
+                    <View key={`${fmt(day.date)}-${menu.name}`} style={styles.mealItem}>
                       <View style={styles.mealBullet} />
                       <Text style={styles.mealName}>
                         {menu.name}

--- a/src/api/meal.ts
+++ b/src/api/meal.ts
@@ -88,7 +88,10 @@ export const getMealsForChild = (
 ): MealMenu[] => {
   const group = schoolMeals.find((g) => g.officeCode === officeCode && g.schoolCode === schoolCode);
   if (!group) return [];
-  const entry = group.meals.find((m) => m.date === date);
+  const entry =
+    group.meals.find(
+      (m) => m.date === date && (m.mealCode === '2' || m.mealName.includes('중식'))
+    ) ?? group.meals.find((m) => m.date === date);
   if (!entry?.dishName) return [];
   return parseDishName(entry.dishName);
 };

--- a/src/api/meal.ts
+++ b/src/api/meal.ts
@@ -1,0 +1,150 @@
+import axios from 'axios';
+import { apiClient } from './auth';
+
+const wrapError = (error: unknown): Error => {
+  if (axios.isAxiosError(error) && error.response?.data?.code) {
+    return new Error(error.response.data.message ?? '알 수 없는 오류');
+  }
+  return error instanceof Error ? error : new Error(String(error));
+};
+
+export interface MealMenu {
+  name: string;
+  allergyNums: number[];
+}
+
+export interface SchoolMealChild {
+  childId: number;
+  childName: string;
+  grade: number;
+  colorCode: string;
+}
+
+export interface SchoolMealEntry {
+  date: string;
+  mealCode: string;
+  mealName: string;
+  mealPeopleCount: number;
+  dishName: string;
+  originInfo: string;
+  calorieInfo: string;
+  nutritionInfo: string;
+}
+
+export interface SchoolMealGroup {
+  schoolGroupKey: string;
+  officeCode: string;
+  schoolCode: string;
+  schoolName: string;
+  childIds: number[];
+  children: SchoolMealChild[];
+  meals: SchoolMealEntry[];
+}
+
+const parseDishLine = (dish: string): MealMenu => {
+  const cleaned = dish
+    .replace(/\*/g, '')
+    .replace(/\(현\)/g, '')
+    .trim();
+  const match = cleaned.match(/^(.*)\s*\(([\d.]+)\)\s*$/);
+  if (match) {
+    return {
+      name: match[1].trim(),
+      allergyNums: match[2]
+        .split('.')
+        .map(Number)
+        .filter((n) => !Number.isNaN(n) && n > 0),
+    };
+  }
+  return { name: cleaned, allergyNums: [] };
+};
+
+export const parseDishName = (dishName: string): MealMenu[] =>
+  dishName
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(parseDishLine);
+
+export const fetchSchoolMeals = async (
+  fromDate: string,
+  toDate: string
+): Promise<SchoolMealGroup[]> => {
+  try {
+    const response = await apiClient.get('/api/v1/calendars/school-meals', {
+      params: { fromDate, toDate },
+    });
+    return response.data.result.schoolMeals ?? [];
+  } catch (error) {
+    throw wrapError(error);
+  }
+};
+
+export const getMealsForChild = (
+  schoolMeals: SchoolMealGroup[],
+  officeCode: string,
+  schoolCode: string,
+  date: string
+): MealMenu[] => {
+  const group = schoolMeals.find((g) => g.officeCode === officeCode && g.schoolCode === schoolCode);
+  if (!group) return [];
+  const entry = group.meals.find((m) => m.date === date);
+  if (!entry?.dishName) return [];
+  return parseDishName(entry.dishName);
+};
+
+export interface TimetablePeriod {
+  period: number;
+  subject: string;
+}
+
+export interface SchoolTimetableEntry {
+  date: string;
+  academicYear: string;
+  semester: string;
+  grade: number;
+  className: string;
+  period: number;
+  content: string;
+}
+
+export interface SchoolTimetableGroup {
+  schoolGroupKey: string;
+  officeCode: string;
+  schoolCode: string;
+  schoolName: string;
+  childIds: number[];
+  children: SchoolMealChild[];
+  timetables: SchoolTimetableEntry[];
+}
+
+export const fetchSchoolTimetables = async (
+  fromDate: string,
+  toDate: string
+): Promise<SchoolTimetableGroup[]> => {
+  try {
+    const response = await apiClient.get('/api/v1/calendars/elementary-timetables', {
+      params: { fromDate, toDate },
+    });
+    return response.data.result.schoolTimetables ?? [];
+  } catch (error) {
+    throw wrapError(error);
+  }
+};
+
+export const getPeriodsForChild = (
+  schoolTimetables: SchoolTimetableGroup[],
+  officeCode: string,
+  schoolCode: string,
+  grade: number,
+  date: string
+): TimetablePeriod[] => {
+  const group = schoolTimetables.find(
+    (g) => g.officeCode === officeCode && g.schoolCode === schoolCode
+  );
+  if (!group) return [];
+  return group.timetables
+    .filter((t) => t.date === date && t.grade === grade && t.className === '1')
+    .sort((a, b) => a.period - b.period)
+    .map((t) => ({ period: t.period, subject: t.content }));
+};

--- a/src/components/home/MealTimetableWidget.tsx
+++ b/src/components/home/MealTimetableWidget.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import {
   View,
   Text,
@@ -70,6 +70,16 @@ const MealCard = ({ cardWidth, items, meals, loading }: MealCardProps) => {
   slideToRef.current = slideTo;
   const itemsLengthRef = useRef(items.length);
   itemsLengthRef.current = items.length;
+
+  useEffect(() => {
+    if (!items.length) return;
+    const clamped = Math.min(activeIdxRef.current, items.length - 1);
+    if (clamped !== activeIdxRef.current) {
+      activeIdxRef.current = clamped;
+      setActiveIdx(clamped);
+    }
+    translateX.setValue(-clamped * cardWidth);
+  }, [items.length, cardWidth, translateX]);
 
   useEffect(() => {
     if (items.length <= 1) return undefined;
@@ -227,6 +237,16 @@ const TimetableCard = ({ cardWidth, items, timetables, loading }: TimetableCardP
   itemsLengthRef.current = items.length;
 
   useEffect(() => {
+    if (!items.length) return;
+    const clamped = Math.min(activeIdxRef.current, items.length - 1);
+    if (clamped !== activeIdxRef.current) {
+      activeIdxRef.current = clamped;
+      setActiveIdx(clamped);
+    }
+    translateX.setValue(-clamped * cardWidth);
+  }, [items.length, cardWidth, translateX]);
+
+  useEffect(() => {
     if (items.length <= 1) return undefined;
     const interval = setInterval(() => {
       if (!isPausedRef.current) {
@@ -349,7 +369,18 @@ const MealTimetableWidget = () => {
   const childItems = useChildrenStore((s) => s.children);
   const { width: screenWidth } = useWindowDimensions();
   const cardWidth = (screenWidth - HORIZONTAL_PADDING - CARD_GAP) / 2;
-  const today = useMemo(getTodayStr, []);
+  const [today, setToday] = useState(getTodayStr);
+
+  useEffect(() => {
+    const now = new Date();
+    const nextMidnight = new Date(now);
+    nextMidnight.setHours(24, 0, 0, 0);
+    const timeout = setTimeout(
+      () => setToday(getTodayStr()),
+      nextMidnight.getTime() - now.getTime()
+    );
+    return () => clearTimeout(timeout);
+  }, [today]);
 
   const [meals, setMeals] = useState<MealMenu[][]>([]);
   const [timetables, setTimetables] = useState<TimetablePeriod[][]>([]);

--- a/src/components/home/MealTimetableWidget.tsx
+++ b/src/components/home/MealTimetableWidget.tsx
@@ -1,0 +1,408 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  Animated,
+  Easing,
+  PanResponder,
+  ScrollView,
+  ActivityIndicator,
+  useWindowDimensions,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { router } from 'expo-router';
+import { useChildrenStore } from '../../store/childrenStore';
+import {
+  fetchSchoolMeals,
+  getMealsForChild,
+  fetchSchoolTimetables,
+  getPeriodsForChild,
+  MealMenu,
+  TimetablePeriod,
+} from '../../api/meal';
+import { ChildItem } from '../../api/child';
+import colors from '../../constants/colors';
+import styles from '../../styles/home/mealTimetableWidget';
+
+const CARD_GAP = 16;
+const HORIZONTAL_PADDING = 40;
+const SLIDE_DURATION = 550;
+const AUTO_INTERVAL = 5000;
+
+const getTodayStr = (): string => {
+  const d = new Date();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${d.getFullYear()}-${m}-${day}`;
+};
+
+interface MealCardProps {
+  cardWidth: number;
+  items: ChildItem[];
+  meals: MealMenu[][];
+  loading: boolean;
+}
+
+const MealCard = ({ cardWidth, items, meals, loading }: MealCardProps) => {
+  const [activeIdx, setActiveIdx] = useState(0);
+  const activeIdxRef = useRef(0);
+  const isPausedRef = useRef(false);
+  const translateX = useRef(new Animated.Value(0)).current;
+  const activeChild = items[activeIdx];
+
+  const slideTo = useCallback(
+    (idx: number) => {
+      activeIdxRef.current = idx;
+      setActiveIdx(idx);
+      Animated.timing(translateX, {
+        toValue: -idx * cardWidth,
+        duration: SLIDE_DURATION,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }).start();
+    },
+    [cardWidth, translateX]
+  );
+
+  const slideToRef = useRef(slideTo);
+  slideToRef.current = slideTo;
+  const itemsLengthRef = useRef(items.length);
+  itemsLengthRef.current = items.length;
+
+  useEffect(() => {
+    if (items.length <= 1) return undefined;
+    const interval = setInterval(() => {
+      if (!isPausedRef.current) {
+        const next = (activeIdxRef.current + 1) % items.length;
+        slideTo(next);
+      }
+    }, AUTO_INTERVAL);
+    return () => clearInterval(interval);
+  }, [items.length, slideTo]);
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onMoveShouldSetPanResponder: (_, g) => Math.abs(g.dx) > 8 && Math.abs(g.dx) > Math.abs(g.dy),
+      onPanResponderRelease: (_, g) => {
+        const len = itemsLengthRef.current;
+        if (g.dx < -40) {
+          slideToRef.current((activeIdxRef.current + 1) % len);
+        } else if (g.dx > 40) {
+          slideToRef.current((activeIdxRef.current - 1 + len) % len);
+        }
+      },
+    })
+  ).current;
+
+  const renderMenuContent = (menus: MealMenu[]) => {
+    if (loading) {
+      return <ActivityIndicator color={colors.primary[400]} style={styles.loadingIndicator} />;
+    }
+    if (!menus.length) {
+      return <Text style={styles.emptyText}>급식 정보가 없어요</Text>;
+    }
+    return (
+      <View style={styles.menuList}>
+        {menus.map((menu) => (
+          <View key={menu.name} style={styles.menuItem}>
+            <View style={styles.menuBullet} />
+            <Text style={styles.menuName}>
+              {menu.name}
+              {menu.allergyNums.length > 0 && (
+                <Text style={styles.allergyText}> ({menu.allergyNums.join('.')})</Text>
+              )}
+            </Text>
+          </View>
+        ))}
+      </View>
+    );
+  };
+
+  return (
+    <View
+      style={styles.card}
+      onTouchStart={() => {
+        isPausedRef.current = true;
+      }}
+      onTouchEnd={() => {
+        isPausedRef.current = false;
+      }}
+      onTouchCancel={() => {
+        isPausedRef.current = false;
+      }}
+    >
+      <View style={styles.cardFixedSection}>
+        <View style={styles.cardHeader}>
+          <View style={[styles.iconBox, { backgroundColor: colors.primary[100] }]}>
+            <Ionicons name="restaurant-outline" size={22} color={colors.primary[500]} />
+          </View>
+          <View style={styles.headerTexts}>
+            <Text style={[styles.cardLabel, { color: colors.primary[500] }]}>오늘의 급식</Text>
+            <Text style={styles.cardTitle}>점심 메뉴</Text>
+          </View>
+        </View>
+        <View style={styles.childRow}>
+          <View style={[styles.childDot, { backgroundColor: activeChild.colorCode }]} />
+          <Text style={styles.childText} numberOfLines={1}>
+            {activeChild.name} · {activeChild.schoolName}
+          </Text>
+        </View>
+        <View style={styles.divider} />
+      </View>
+
+      <View
+        style={styles.menuAreaContainer}
+        {...(items.length > 1 ? panResponder.panHandlers : {})}
+      >
+        <Animated.View
+          style={[
+            styles.slideRow,
+            { width: cardWidth * items.length, transform: [{ translateX }] },
+          ]}
+        >
+          {items.map((item, index) => (
+            <View key={String(item.id)} style={[{ width: cardWidth }, styles.menuPageContent]}>
+              <ScrollView
+                showsVerticalScrollIndicator={false}
+                nestedScrollEnabled
+                style={styles.scrollArea}
+              >
+                {renderMenuContent(meals[index] ?? [])}
+              </ScrollView>
+            </View>
+          ))}
+        </Animated.View>
+      </View>
+
+      {items.length > 1 && (
+        <View style={styles.dotsRow}>
+          {items.map((item, idx) => (
+            <View
+              key={item.id}
+              style={[
+                styles.dot,
+                { backgroundColor: idx === activeIdx ? colors.primary[500] : colors.gray[200] },
+              ]}
+            />
+          ))}
+        </View>
+      )}
+    </View>
+  );
+};
+
+interface TimetableCardProps {
+  cardWidth: number;
+  items: ChildItem[];
+  timetables: TimetablePeriod[][];
+  loading: boolean;
+}
+
+const TimetableCard = ({ cardWidth, items, timetables, loading }: TimetableCardProps) => {
+  const [activeIdx, setActiveIdx] = useState(0);
+  const activeIdxRef = useRef(0);
+  const isPausedRef = useRef(false);
+  const translateX = useRef(new Animated.Value(0)).current;
+  const activeChild = items[activeIdx];
+
+  const slideTo = useCallback(
+    (idx: number) => {
+      activeIdxRef.current = idx;
+      setActiveIdx(idx);
+      Animated.timing(translateX, {
+        toValue: -idx * cardWidth,
+        duration: SLIDE_DURATION,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }).start();
+    },
+    [cardWidth, translateX]
+  );
+
+  const slideToRef = useRef(slideTo);
+  slideToRef.current = slideTo;
+  const itemsLengthRef = useRef(items.length);
+  itemsLengthRef.current = items.length;
+
+  useEffect(() => {
+    if (items.length <= 1) return undefined;
+    const interval = setInterval(() => {
+      if (!isPausedRef.current) {
+        const next = (activeIdxRef.current + 1) % items.length;
+        slideTo(next);
+      }
+    }, AUTO_INTERVAL);
+    return () => clearInterval(interval);
+  }, [items.length, slideTo]);
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onMoveShouldSetPanResponder: (_, g) => Math.abs(g.dx) > 8 && Math.abs(g.dx) > Math.abs(g.dy),
+      onPanResponderRelease: (_, g) => {
+        const len = itemsLengthRef.current;
+        if (g.dx < -40) {
+          slideToRef.current((activeIdxRef.current + 1) % len);
+        } else if (g.dx > 40) {
+          slideToRef.current((activeIdxRef.current - 1 + len) % len);
+        }
+      },
+    })
+  ).current;
+
+  const renderTimetableContent = (periods: TimetablePeriod[]) => {
+    if (loading) {
+      return <ActivityIndicator color={colors.secondary[500]} style={styles.loadingIndicator} />;
+    }
+    if (!periods.length) {
+      return <Text style={styles.emptyText}>시간표 정보가 없어요</Text>;
+    }
+    return (
+      <View style={styles.periodList}>
+        {periods.map((p) => (
+          <View key={p.period} style={styles.periodItem}>
+            <View style={styles.periodBadge}>
+              <Text style={styles.periodBadgeText}>{p.period}교시</Text>
+            </View>
+            <Text style={styles.periodSubject}>{p.subject}</Text>
+          </View>
+        ))}
+      </View>
+    );
+  };
+
+  return (
+    <View
+      style={styles.card}
+      onTouchStart={() => {
+        isPausedRef.current = true;
+      }}
+      onTouchEnd={() => {
+        isPausedRef.current = false;
+      }}
+      onTouchCancel={() => {
+        isPausedRef.current = false;
+      }}
+    >
+      <View style={styles.cardFixedSection}>
+        <View style={styles.cardHeader}>
+          <View style={[styles.iconBox, { backgroundColor: colors.secondary[100] }]}>
+            <Ionicons name="alarm-outline" size={22} color={colors.secondary[600]} />
+          </View>
+          <View style={styles.headerTexts}>
+            <Text style={[styles.cardLabel, { color: colors.secondary[600] }]}>오늘의 시간표</Text>
+            <Text style={styles.cardTitle}>수업 일정</Text>
+          </View>
+        </View>
+        <View style={styles.childRow}>
+          <View style={[styles.childDot, { backgroundColor: activeChild.colorCode }]} />
+          <Text style={styles.childText} numberOfLines={1}>
+            {activeChild.name} · {activeChild.schoolName}
+          </Text>
+        </View>
+        <View style={styles.divider} />
+      </View>
+
+      <View
+        style={styles.menuAreaContainer}
+        {...(items.length > 1 ? panResponder.panHandlers : {})}
+      >
+        <Animated.View
+          style={[
+            styles.slideRow,
+            { width: cardWidth * items.length, transform: [{ translateX }] },
+          ]}
+        >
+          {items.map((item, index) => (
+            <View key={String(item.id)} style={[{ width: cardWidth }, styles.menuPageContent]}>
+              <ScrollView
+                showsVerticalScrollIndicator={false}
+                nestedScrollEnabled
+                style={styles.scrollArea}
+              >
+                {renderTimetableContent(timetables[index] ?? [])}
+              </ScrollView>
+            </View>
+          ))}
+        </Animated.View>
+      </View>
+
+      {items.length > 1 && (
+        <View style={styles.dotsRow}>
+          {items.map((item, idx) => (
+            <View
+              key={item.id}
+              style={[
+                styles.dot,
+                { backgroundColor: idx === activeIdx ? colors.secondary[500] : colors.gray[200] },
+              ]}
+            />
+          ))}
+        </View>
+      )}
+    </View>
+  );
+};
+
+const MealTimetableWidget = () => {
+  const childItems = useChildrenStore((s) => s.children);
+  const { width: screenWidth } = useWindowDimensions();
+  const cardWidth = (screenWidth - HORIZONTAL_PADDING - CARD_GAP) / 2;
+  const today = useMemo(getTodayStr, []);
+
+  const [meals, setMeals] = useState<MealMenu[][]>([]);
+  const [timetables, setTimetables] = useState<TimetablePeriod[][]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!childItems.length) return;
+    setLoading(true);
+    Promise.all([
+      fetchSchoolMeals(today, today)
+        .then((schoolMeals) =>
+          childItems.map((c) => getMealsForChild(schoolMeals, c.officeCode, c.schoolCode, today))
+        )
+        .catch(() => childItems.map(() => [])),
+      fetchSchoolTimetables(today, today)
+        .then((schoolTimetables) =>
+          childItems.map((c) =>
+            getPeriodsForChild(schoolTimetables, c.officeCode, c.schoolCode, c.grade, today)
+          )
+        )
+        .catch(() => childItems.map(() => [])),
+    ])
+      .then(([m, t]) => {
+        setMeals(m);
+        setTimetables(t);
+      })
+      .finally(() => setLoading(false));
+  }, [childItems, today]);
+
+  if (!childItems.length) return null;
+
+  return (
+    <View style={styles.section}>
+      <View style={styles.sectionHeader}>
+        <Text style={styles.sectionTitle}>급식·시간표</Text>
+        <TouchableOpacity onPress={() => router.push('/meal-timetable')} activeOpacity={0.7}>
+          <View style={styles.viewAllRow}>
+            <Text style={styles.viewAllText}>전체보기</Text>
+            <Ionicons name="chevron-forward" size={14} color={colors.text.secondary} />
+          </View>
+        </TouchableOpacity>
+      </View>
+      <View style={styles.cardsRow}>
+        <MealCard cardWidth={cardWidth} items={childItems} meals={meals} loading={loading} />
+        <TimetableCard
+          cardWidth={cardWidth}
+          items={childItems}
+          timetables={timetables}
+          loading={loading}
+        />
+      </View>
+    </View>
+  );
+};
+
+export default MealTimetableWidget;

--- a/src/styles/home/mealTimetableWidget.ts
+++ b/src/styles/home/mealTimetableWidget.ts
@@ -1,0 +1,184 @@
+import { StyleSheet } from 'react-native';
+import colors from '../../constants/colors';
+import fonts from '../../constants/fonts';
+
+const styles = StyleSheet.create({
+  section: {
+    gap: 16,
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontFamily: fonts.semiBold,
+    color: colors.text.primary,
+  },
+  viewAllRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 2,
+  },
+  viewAllText: {
+    fontSize: 13,
+    fontFamily: fonts.medium,
+    color: colors.text.secondary,
+  },
+  cardsRow: {
+    flexDirection: 'row',
+    gap: 16,
+  },
+  card: {
+    flex: 1,
+    borderRadius: 20,
+    backgroundColor: colors.text.white,
+    shadowColor: colors.gray[300],
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+    overflow: 'hidden',
+  },
+  cardFixedSection: {
+    padding: 15,
+    paddingBottom: 0,
+    gap: 12,
+  },
+  menuAreaContainer: {
+    overflow: 'hidden',
+  },
+  menuPageContent: {
+    paddingHorizontal: 15,
+    paddingTop: 12,
+    paddingBottom: 12,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  iconBox: {
+    width: 44,
+    height: 44,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTexts: {
+    flex: 1,
+    gap: 2,
+  },
+  cardLabel: {
+    fontSize: 11,
+    fontFamily: fonts.medium,
+  },
+  cardTitle: {
+    fontSize: 16,
+    fontFamily: fonts.bold,
+    color: colors.text.primary,
+  },
+  childRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  childDot: {
+    width: 6,
+    height: 6,
+    borderRadius: 100,
+  },
+  childText: {
+    fontSize: 11,
+    fontFamily: fonts.medium,
+    color: colors.text.secondary,
+    flex: 1,
+  },
+  menuList: {
+    gap: 7,
+  },
+  menuItem: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 7,
+  },
+  menuBullet: {
+    width: 4,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: colors.text.primary,
+    marginTop: 7,
+  },
+  menuName: {
+    fontSize: 12,
+    fontFamily: fonts.regular,
+    color: colors.text.primary,
+    flex: 1,
+    lineHeight: 18,
+  },
+  allergyText: {
+    color: colors.primary[500],
+  },
+  periodList: {
+    gap: 8,
+  },
+  periodItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  periodBadge: {
+    backgroundColor: colors.secondary[600],
+    borderRadius: 12,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    minWidth: 44,
+    alignItems: 'center',
+  },
+  periodBadgeText: {
+    fontSize: 11,
+    fontFamily: fonts.semiBold,
+    color: colors.text.white,
+  },
+  periodSubject: {
+    fontSize: 12,
+    fontFamily: fonts.medium,
+    color: colors.text.primary,
+    flex: 1,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: colors.gray[100],
+    marginHorizontal: -15,
+  },
+  scrollArea: {
+    maxHeight: 210,
+  },
+  loadingIndicator: {
+    paddingVertical: 20,
+  },
+  slideRow: {
+    flexDirection: 'row',
+  },
+  emptyText: {
+    fontSize: 12,
+    fontFamily: fonts.regular,
+    color: colors.text.secondary,
+    textAlign: 'center',
+    paddingVertical: 20,
+  },
+  dotsRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: 6,
+    paddingBottom: 14,
+  },
+  dot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+  },
+});
+
+export default styles;

--- a/src/styles/meal-timetable/index.ts
+++ b/src/styles/meal-timetable/index.ts
@@ -1,0 +1,273 @@
+import { StyleSheet } from 'react-native';
+import colors from '../../constants/colors';
+import fonts from '../../constants/fonts';
+import layout from '../../constants/layout';
+
+export const GREEN = '#4CAF50';
+export const GREEN_LIGHT = '#E8F5E9';
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.text.white,
+  },
+  childTabsWrap: {
+    backgroundColor: colors.text.white,
+    paddingHorizontal: layout.screenPaddingHorizontal,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.gray[100],
+  },
+  childTabs: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  childTab: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 20,
+    backgroundColor: colors.gray[100],
+  },
+  childTabActive: {
+    backgroundColor: colors.primary[100],
+  },
+  childTabDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  childTabText: {
+    fontSize: 13,
+    fontFamily: fonts.medium,
+    color: colors.text.secondary,
+  },
+  childTabTextActive: {
+    fontFamily: fonts.semiBold,
+    color: colors.primary[600],
+  },
+  tabBar: {
+    flexDirection: 'row',
+    backgroundColor: colors.text.white,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.gray[100],
+  },
+  tabItem: {
+    flex: 1,
+    paddingVertical: 14,
+    alignItems: 'center',
+    borderBottomWidth: 2,
+    borderBottomColor: 'transparent',
+  },
+  tabItemActive: {
+    borderBottomColor: colors.primary[500],
+  },
+  tabText: {
+    fontSize: 15,
+    fontFamily: fonts.medium,
+    color: colors.text.secondary,
+  },
+  tabTextActive: {
+    fontFamily: fonts.semiBold,
+    color: colors.primary[600],
+  },
+  contentArea: {
+    flex: 1,
+    backgroundColor: colors.gray[100],
+  },
+  content: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingHorizontal: layout.screenPaddingHorizontal,
+    paddingTop: 20,
+    paddingBottom: layout.screenPaddingBottom,
+  },
+  loadingWrap: {
+    paddingVertical: 60,
+    alignItems: 'center',
+  },
+
+  // Timetable
+  tableWrap: {
+    backgroundColor: colors.text.white,
+    borderWidth: 1,
+    borderColor: colors.gray[100],
+    borderRadius: 16,
+    overflow: 'hidden',
+    shadowColor: colors.gray[300],
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  tableHeaderRow: {
+    flexDirection: 'row',
+    borderBottomWidth: 1,
+    borderBottomColor: colors.gray[100],
+  },
+  tableRow: {
+    flexDirection: 'row',
+    borderBottomWidth: 1,
+    borderBottomColor: colors.gray[100],
+  },
+  tableRowEven: {
+    backgroundColor: colors.gray[100],
+  },
+  tablePeriodCell: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 12,
+    borderRightWidth: 1,
+    borderRightColor: colors.gray[100],
+  },
+  tablePeriodText: {
+    fontSize: 12,
+    fontFamily: fonts.medium,
+    color: colors.text.secondary,
+  },
+  tableDayHeader: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 10,
+    borderRightWidth: 1,
+    borderRightColor: colors.gray[100],
+    gap: 2,
+  },
+  tableDayDate: {
+    fontSize: 10,
+    fontFamily: fonts.regular,
+    color: colors.text.secondary,
+  },
+  tableDayName: {
+    fontSize: 14,
+    fontFamily: fonts.semiBold,
+    color: colors.text.primary,
+  },
+  todayHeaderCol: {
+    backgroundColor: colors.primary[0],
+  },
+  todayText: {
+    color: colors.primary[600],
+  },
+  tableCell: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 10,
+    paddingHorizontal: 2,
+    borderRightWidth: 1,
+    borderRightColor: colors.gray[100],
+  },
+  todayCell: {
+    backgroundColor: colors.primary[0],
+  },
+  tableCellText: {
+    fontSize: 11,
+    fontFamily: fonts.medium,
+    color: colors.text.primary,
+    textAlign: 'center',
+  },
+
+  // Meal timeline
+  timeline: {
+    paddingTop: 4,
+  },
+  timelineItem: {
+    flexDirection: 'row',
+    gap: 14,
+  },
+  timelineLeft: {
+    width: 20,
+    alignItems: 'center',
+    paddingTop: 3,
+  },
+  timelineDot: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+    backgroundColor: colors.gray[200],
+  },
+  timelineDotActive: {
+    backgroundColor: colors.secondary[500],
+  },
+  timelineLine: {
+    flex: 1,
+    width: 2,
+    backgroundColor: '#E2E4E8',
+    marginTop: 4,
+  },
+  timelineRight: {
+    flex: 1,
+    paddingBottom: 24,
+  },
+  timelineDateRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 10,
+  },
+  timelineDateText: {
+    fontSize: 15,
+    fontFamily: fonts.semiBold,
+    color: colors.text.secondary,
+  },
+  timelineDateTextToday: {
+    color: colors.text.primary,
+  },
+  todayBadge: {
+    backgroundColor: colors.secondary[100],
+    borderRadius: 8,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+  },
+  todayBadgeText: {
+    fontSize: 11,
+    fontFamily: fonts.semiBold,
+    color: colors.secondary[600],
+  },
+  mealCard: {
+    backgroundColor: colors.text.white,
+    borderRadius: 14,
+    padding: 16,
+    gap: 9,
+    shadowColor: colors.gray[300],
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 3,
+    elevation: 2,
+  },
+  mealItem: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 8,
+  },
+  mealBullet: {
+    width: 5,
+    height: 5,
+    borderRadius: 3,
+    backgroundColor: colors.text.secondary,
+    marginTop: 8,
+  },
+  mealName: {
+    flex: 1,
+    fontSize: 14,
+    fontFamily: fonts.regular,
+    color: colors.text.primary,
+    lineHeight: 21,
+  },
+  mealAllergyText: {
+    color: colors.text.secondary,
+    fontSize: 13,
+  },
+  noMealText: {
+    fontSize: 13,
+    fontFamily: fonts.regular,
+    color: colors.text.secondary,
+    textAlign: 'center',
+    paddingVertical: 6,
+  },
+});
+
+export default styles;


### PR DESCRIPTION
## 📌 작업 내용

- 급식·시간표 API 연동 (school-meals, elementary-timetables)
- 홈 화면 급식·시간표 위젯 구현 (자녀별 자동 슬라이드, 스와이프)
- 급식·시간표 전체보기 페이지 구현 (주간 시간표 테이블, 5일치 급식 타임라인)

## 📷 스크린 샷

<table>
  <tr>
    <td align="center">
      <img 
        src="https://github.com/user-attachments/assets/c5707eed-15a2-42e8-81d5-09e784b0463a" 
        alt="화면 1" 
        width="240"
      />
      <br />
      <b>화면 1</b>
    </td>
    <td align="center">
      <img 
        src="https://github.com/user-attachments/assets/1bf803a2-c1e3-4e82-b636-b1b2a2eb3448" 
        alt="화면 2" 
        width="240"
      />
      <br />
      <b>화면 2</b>
    </td>
    <td align="center">
      <img 
        src="https://github.com/user-attachments/assets/9e66cbbc-d418-4e8e-812c-22ddd2fe8ef8" 
        alt="화면 3" 
        width="240"
      />
      <br />
      <b>화면 3</b>
    </td>
  </tr>
</table>


## ⚠️ 참고 사항

- 시간표 반 정보는 현재 1반 고정 (추후 자녀 데이터 연동 필요)

## 🔗 관련 이슈

Closes #82


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 홈 화면에 급식·시간표 위젯 추가 - 오늘의 급식 메뉴와 수업 시간표를 한눈에 확인 가능
  * 전담 급식·시간표 페이지 신규 개설 - 여러 자녀 선택 탭과 향후 5일 상세 정보 조회 가능
  * 카드 자동 슬라이드 및 스와이프 제스처 지원 - 자녀별 정보를 더욱 직관적으로 탐색

<!-- end of auto-generated comment: release notes by coderabbit.ai -->