### PR TITLE
✨ [Feature] 학사 일정 구현 및 API 연동 (#86)

### DIFF
--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -105,6 +105,7 @@ const CalendarScreen = () => {
   const weeklyReqIdRef = useRef(0);
   const monthlyReqIdRef = useRef(0);
   const dailyReqIdRef = useRef(0);
+  const schoolReqIdRef = useRef(0);
 
   useEffect(() => {
     shouldAutoScrollRef.current = weekOffset === 0;
@@ -173,27 +174,27 @@ const CalendarScreen = () => {
 
   // 학사일정
   const schoolFromDate = useMemo(() => {
-    const [y, m] = isWeekMode
-      ? weekDates[0].split('-').map(Number)
-      : [calendarMonth.year, calendarMonth.month + 1];
-    return `${y}-${String(m).padStart(2, '0')}-01`;
+    if (isWeekMode) return weekDates[0];
+    return `${calendarMonth.year}-${String(calendarMonth.month + 1).padStart(2, '0')}-01`;
   }, [isWeekMode, weekDates, calendarMonth.year, calendarMonth.month]);
 
   const schoolToDate = useMemo(() => {
-    const [y, m] = isWeekMode
-      ? weekDates[0].split('-').map(Number)
-      : [calendarMonth.year, calendarMonth.month + 1];
-    const lastDay = new Date(y, m, 0).getDate();
-    return `${y}-${String(m).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`;
+    if (isWeekMode) return weekDates[6];
+    const lastDay = new Date(calendarMonth.year, calendarMonth.month + 1, 0).getDate();
+    return `${calendarMonth.year}-${String(calendarMonth.month + 1).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`;
   }, [isWeekMode, weekDates, calendarMonth.year, calendarMonth.month]);
 
   useEffect(() => {
+    schoolReqIdRef.current += 1;
+    const reqId = schoolReqIdRef.current;
     fetchSchoolSchedules(schoolFromDate, schoolToDate)
       .then((data) => {
+        if (reqId !== schoolReqIdRef.current) return;
         setCommonHolidays(data.commonHolidays);
         setSchoolGroups(data.schoolSchedules);
       })
       .catch((e) => {
+        if (reqId !== schoolReqIdRef.current) return;
         // eslint-disable-next-line no-console
         console.error('fetchSchoolSchedules failed:', e);
       });

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -14,11 +14,20 @@ import {
   fetchMonthlyMarkers,
   fetchDailyEvents,
   fetchWeeklyEvents,
+  fetchSchoolSchedules,
   completeChecklist,
   type CalendarEvent,
   type WeeklyResult,
   type MonthlyMarker,
+  type HolidayItem,
+  type SchoolGroup,
 } from '../../src/api/calendar';
+import {
+  getHolidaysForDate,
+  getAcademicSchedulesForDate,
+  getSchoolDotsForDate,
+} from '../../src/utils/schoolSchedule';
+import SchoolScheduleRow from '../../src/components/calendar/SchoolScheduleRow';
 import { useChildrenStore } from '../../src/store/childrenStore';
 
 const todayDate = new Date();
@@ -52,6 +61,8 @@ const CalendarScreen = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [isDailyLoading, setIsDailyLoading] = useState(false);
   const [isWeekMode, setIsWeekMode] = useState<boolean>(true);
+  const [schoolGroups, setSchoolGroups] = useState<SchoolGroup[]>([]);
+  const [commonHolidays, setCommonHolidays] = useState<HolidayItem[]>([]);
   const [weekOffset, setWeekOffset] = useState<number>(0);
   const [calendarMonth, setCalendarMonth] = useState({
     year: todayDate.getFullYear(),
@@ -79,6 +90,11 @@ const CalendarScreen = () => {
       }
       setFocusKey((k) => k + 1);
     }, [])
+  );
+
+  const selectedChildId = useMemo(
+    () => children.find((c) => c.name === selectedChildName)?.id,
+    [children, selectedChildName]
   );
 
   const weekScrollRef = useRef<ScrollView>(null);
@@ -155,6 +171,41 @@ const CalendarScreen = () => {
       });
   }, [isWeekMode, selectedDate, selectedChildName, focusKey]);
 
+  // 학사일정
+  const schoolFromDate = useMemo(() => {
+    const [y, m] = isWeekMode
+      ? weekDates[0].split('-').map(Number)
+      : [calendarMonth.year, calendarMonth.month + 1];
+    return `${y}-${String(m).padStart(2, '0')}-01`;
+  }, [isWeekMode, weekDates, calendarMonth.year, calendarMonth.month]);
+
+  const schoolToDate = useMemo(() => {
+    const [y, m] = isWeekMode
+      ? weekDates[0].split('-').map(Number)
+      : [calendarMonth.year, calendarMonth.month + 1];
+    const lastDay = new Date(y, m, 0).getDate();
+    return `${y}-${String(m).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`;
+  }, [isWeekMode, weekDates, calendarMonth.year, calendarMonth.month]);
+
+  useEffect(() => {
+    fetchSchoolSchedules(schoolFromDate, schoolToDate)
+      .then((data) => {
+        setCommonHolidays(data.commonHolidays);
+        setSchoolGroups(data.schoolSchedules);
+      })
+      .catch((e) => {
+        // eslint-disable-next-line no-console
+        console.error('fetchSchoolSchedules failed:', e);
+      });
+  }, [schoolFromDate, schoolToDate, focusKey]);
+
+  type SchoolDisplayEntry = {
+    type: 'holiday' | 'academic';
+    item: HolidayItem;
+    schoolGroupKey?: string;
+    childNames?: string[];
+  };
+
   const markedDatesMap = useMemo(() => {
     const map: Record<string, { dots: { key: string; color: string }[] }> = {};
     monthlyMarkers.forEach(({ date, childName, childColor }) => {
@@ -163,26 +214,89 @@ const CalendarScreen = () => {
         map[date].dots.push({ key: childName, color: childColor });
       }
     });
+    // 학교 도트 병합
+    const allSchoolDates = new Set<string>();
+    commonHolidays.forEach((h) => allSchoolDates.add(h.date));
+    schoolGroups.forEach((g) => g.schedules.forEach((s) => allSchoolDates.add(s.date)));
+    allSchoolDates.forEach((date) => {
+      const schoolDots = getSchoolDotsForDate(commonHolidays, schoolGroups, date);
+      schoolDots.forEach((dot) => {
+        if (!map[date]) map[date] = { dots: [] };
+        if (!map[date].dots.find((d) => d.key === dot.key)) map[date].dots.push(dot);
+      });
+    });
     return map;
-  }, [monthlyMarkers]);
+  }, [monthlyMarkers, commonHolidays, schoolGroups]);
 
   const weekMarkedDates = useMemo(() => {
     if (!weeklyData) return {};
     const record: Record<string, { dots: { key: string; color: string }[] }> = {};
     weeklyData.days.forEach((day) => {
       if (day.events.length > 0) {
-        record[day.date] = {
-          dots: day.events.map((e) => ({ key: String(e.eventId), color: e.calendarColor })),
-        };
+        const dots: { key: string; color: string }[] = [];
+        day.events.forEach((e) => {
+          const key = e.childName ?? e.calendarColor;
+          if (!dots.find((d) => d.key === key)) {
+            dots.push({ key, color: e.calendarColor });
+          }
+        });
+        record[day.date] = { dots };
       }
     });
+    // 학교 도트 병합
+    weekDates.forEach((date) => {
+      const schoolDots = getSchoolDotsForDate(commonHolidays, schoolGroups, date);
+      schoolDots.forEach((dot) => {
+        if (!record[date]) record[date] = { dots: [] };
+        if (!record[date].dots.find((d) => d.key === dot.key)) record[date].dots.push(dot);
+      });
+    });
     return record;
-  }, [weeklyData]);
+  }, [weeklyData, weekDates, commonHolidays, schoolGroups]);
 
-  const weekEventGroups = useMemo(() => {
-    if (!weeklyData) return [];
-    return weeklyData.days.filter((d) => d.events.length > 0);
-  }, [weeklyData]);
+  const daySchoolSchedules = useMemo(
+    (): SchoolDisplayEntry[] => [
+      ...getHolidaysForDate(commonHolidays, selectedDate).map((item) => ({
+        type: 'holiday' as const,
+        item,
+      })),
+      ...getAcademicSchedulesForDate(schoolGroups, selectedDate, selectedChildId).map((e) => ({
+        type: 'academic' as const,
+        ...e,
+      })),
+    ],
+    [commonHolidays, schoolGroups, selectedDate, selectedChildId]
+  );
+
+  const weekDisplayGroups = useMemo(() => {
+    const eventsMap: Record<string, CalendarEvent[]> = {};
+    (weeklyData?.days ?? []).forEach((d) => {
+      eventsMap[d.date] = d.events;
+    });
+    const schoolMap: Record<string, SchoolDisplayEntry[]> = {};
+    weekDates.forEach((date) => {
+      const holidays = getHolidaysForDate(commonHolidays, date).map((item) => ({
+        type: 'holiday' as const,
+        item,
+      }));
+      const academic = getAcademicSchedulesForDate(schoolGroups, date, selectedChildId).map(
+        (e) => ({ type: 'academic' as const, ...e })
+      );
+      const all = [...holidays, ...academic];
+      if (all.length > 0) schoolMap[date] = all;
+    });
+    const activeDates = new Set([
+      ...(weeklyData?.days.filter((d) => d.events.length > 0).map((d) => d.date) ?? []),
+      ...Object.keys(schoolMap),
+    ]);
+    return weekDates
+      .filter((d) => activeDates.has(d))
+      .map((d) => ({
+        date: d,
+        events: eventsMap[d] ?? [],
+        schoolSchedules: schoolMap[d] ?? [],
+      }));
+  }, [weeklyData, weekDates, commonHolidays, schoolGroups, selectedChildId]);
 
   const toggleExpand = (id: number) => {
     setExpandedIds((prev) => {
@@ -334,10 +448,10 @@ const CalendarScreen = () => {
               }}
             >
               <View style={styles.weekListContent}>
-                {weekEventGroups.length === 0 ? (
+                {weekDisplayGroups.length === 0 ? (
                   <Text style={styles.emptyText}>{t('calendar.emptyWeek')}</Text>
                 ) : (
-                  weekEventGroups.map((group) => (
+                  weekDisplayGroups.map((group) => (
                     <View
                       key={group.date}
                       onLayout={(e) => {
@@ -350,6 +464,14 @@ const CalendarScreen = () => {
                         {formatWeekDateHeader(group.date, i18n.language)}
                       </Text>
                       <View style={styles.cardGroup}>
+                        {group.schoolSchedules.map((entry) => (
+                          <SchoolScheduleRow
+                            key={`${entry.item.date}-${entry.item.eventName}-${entry.schoolGroupKey ?? entry.type}`}
+                            item={entry.item}
+                            type={entry.type}
+                            childNames={entry.childNames}
+                          />
+                        ))}
                         {group.events.map((event) => (
                           <EventCard
                             key={event.eventId}
@@ -392,9 +514,18 @@ const CalendarScreen = () => {
               <Text style={styles.dayLabel}>{formatDayLabel(selectedDate, i18n.language)}</Text>
               <View style={styles.listContent}>
                 {isDailyLoading && <ActivityIndicator size="small" color={colors.primary[400]} />}
-                {!isDailyLoading && dayEvents.length === 0 && (
+                {!isDailyLoading && daySchoolSchedules.length === 0 && dayEvents.length === 0 && (
                   <Text style={styles.emptyText}>{t('calendar.emptyDay')}</Text>
                 )}
+                {!isDailyLoading &&
+                  daySchoolSchedules.map((entry) => (
+                    <SchoolScheduleRow
+                      key={`${entry.item.date}-${entry.item.eventName}-${entry.schoolGroupKey ?? entry.type}`}
+                      item={entry.item}
+                      type={entry.type}
+                      childNames={entry.childNames}
+                    />
+                  ))}
                 {!isDailyLoading &&
                   dayEvents.map((event) => (
                     <EventCard

--- a/src/api/calendar.ts
+++ b/src/api/calendar.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import * as SecureStore from 'expo-secure-store';
 import { apiClient } from './auth';
 
+
 export class CalendarApiError extends Error {
   constructor(
     public readonly code: string,
@@ -228,6 +229,65 @@ export const injectCalendarPreviewDummy = async (
     throw wrapError(error);
   }
 };
+
+// ─── 학사일정 (NEIS) ────────────────────────────────────────────────────────
+
+export interface GradeEventYn {
+  grade1: 'Y' | 'N';
+  grade2: 'Y' | 'N';
+  grade3: 'Y' | 'N';
+  grade4: 'Y' | 'N';
+  grade5: 'Y' | 'N';
+  grade6: 'Y' | 'N';
+}
+
+export interface HolidayItem {
+  date: string;
+  academicYear: string;
+  eventName: string;
+  eventContent: string;
+  gradeEventYn: GradeEventYn;
+}
+
+export interface SchoolGroupChild {
+  childId: number;
+  childName: string;
+  grade: number;
+  colorCode: string;
+}
+
+export interface SchoolGroup {
+  schoolGroupKey: string;
+  officeCode: string;
+  schoolCode: string;
+  schoolName: string;
+  childIds: number[];
+  children: SchoolGroupChild[];
+  schedules: HolidayItem[];
+}
+
+export interface SchoolScheduleResult {
+  commonHolidays: HolidayItem[];
+  schoolSchedules: SchoolGroup[];
+}
+
+export const fetchSchoolSchedules = async (
+  fromDate: string,
+  toDate: string
+): Promise<SchoolScheduleResult> => {
+  try {
+    const headers = await getAuthHeader();
+    const response = await apiClient.get<{ result: SchoolScheduleResult }>(
+      '/api/v1/calendars/school-schedules',
+      { headers, params: { fromDate, toDate } }
+    );
+    return response.data.result;
+  } catch (error) {
+    throw wrapError(error);
+  }
+};
+
+// ────────────────────────────────────────────────────────────────────────────
 
 export const completeChecklist = async (
   checklistId: number,

--- a/src/components/calendar/SchoolScheduleRow.tsx
+++ b/src/components/calendar/SchoolScheduleRow.tsx
@@ -1,0 +1,50 @@
+import { View, Text } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
+import calStyles from '../../styles/calendar/calendar';
+import colors from '../../constants/colors';
+import type { HolidayItem } from '../../api/calendar';
+
+interface SchoolScheduleRowProps {
+  item: HolidayItem;
+  type: 'holiday' | 'academic';
+  childNames?: string[];
+}
+
+const SchoolScheduleRow = ({ item, type, childNames }: SchoolScheduleRowProps) => {
+  const { t } = useTranslation();
+
+  const showHolidayTag = type === 'holiday';
+  const showChildTags = type === 'academic' && childNames && childNames.length > 0;
+
+  return (
+    <View style={calStyles.card}>
+      <View style={calStyles.cardHeader}>
+        {type === 'holiday' && <Ionicons name="flag" size={20} color={colors.gray[300]} />}
+        {type === 'academic' && <Ionicons name="school" size={20} color={colors.gray[300]} />}
+        <Text style={[calStyles.cardLeft, calStyles.cardTitle]} numberOfLines={1}>
+          {item.eventName}
+        </Text>
+        {(showHolidayTag || showChildTags) && (
+          <View style={calStyles.cardTags}>
+            {showHolidayTag && (
+              <View style={calStyles.tag}>
+                <Text style={calStyles.tagText}>{t('calendar.schoolSchedule.holiday')}</Text>
+              </View>
+            )}
+            {showChildTags &&
+              childNames!.map((name) => (
+                <View key={name} style={calStyles.tag}>
+                  <Text style={calStyles.tagText} numberOfLines={1}>
+                    {name}
+                  </Text>
+                </View>
+              ))}
+          </View>
+        )}
+      </View>
+    </View>
+  );
+};
+
+export default SchoolScheduleRow;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -550,6 +550,9 @@
     "checklist": {
       "collapse": "Collapse checklist",
       "expand": "Expand checklist"
+    },
+    "schoolSchedule": {
+      "holiday": "Holiday"
     }
   },
   "document": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -528,6 +528,9 @@
     "checklist": {
       "collapse": "체크리스트 접기",
       "expand": "체크리스트 펼치기"
+    },
+    "schoolSchedule": {
+      "holiday": "공휴일"
     }
   },
   "document": {

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -550,6 +550,9 @@
     "checklist": {
       "collapse": "Thu gọn danh sách",
       "expand": "Mở rộng danh sách"
+    },
+    "schoolSchedule": {
+      "holiday": "Ngày nghỉ"
     }
   },
   "document": {

--- a/src/styles/profile/profile.ts
+++ b/src/styles/profile/profile.ts
@@ -24,6 +24,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 14,
+    position: 'relative',
   },
   avatar: {
     width: 50,
@@ -33,6 +34,7 @@ const styles = StyleSheet.create({
   profileInfo: {
     flex: 1,
     gap: 4,
+    marginRight: 60,
   },
   profileName: {
     fontSize: 17,
@@ -66,8 +68,9 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: colors.secondary[500],
     borderRadius: 999,
-    width: 52,
-    height: 30,
+    minWidth: 52,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/src/styles/profile/profile.ts
+++ b/src/styles/profile/profile.ts
@@ -24,7 +24,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 14,
-    position: 'relative',
   },
   avatar: {
     width: 50,
@@ -34,7 +33,6 @@ const styles = StyleSheet.create({
   profileInfo: {
     flex: 1,
     gap: 4,
-    marginRight: 60,
   },
   profileName: {
     fontSize: 17,
@@ -44,6 +42,7 @@ const styles = StyleSheet.create({
   profileSubRow: {
     flexDirection: 'row',
     alignItems: 'center',
+    flexWrap: 'wrap',
     gap: 6,
   },
   idBadge: {
@@ -69,6 +68,7 @@ const styles = StyleSheet.create({
     borderColor: colors.secondary[500],
     borderRadius: 999,
     minWidth: 52,
+    flexShrink: 0,
     paddingHorizontal: 12,
     paddingVertical: 6,
     alignItems: 'center',

--- a/src/utils/schoolSchedule.ts
+++ b/src/utils/schoolSchedule.ts
@@ -1,0 +1,81 @@
+import colors from '../constants/colors';
+import type { HolidayItem, SchoolGroup, GradeEventYn } from '../api/calendar';
+
+const GRADE_KEYS: Record<number, keyof GradeEventYn> = {
+  1: 'grade1',
+  2: 'grade2',
+  3: 'grade3',
+  4: 'grade4',
+  5: 'grade5',
+  6: 'grade6',
+};
+
+const gradeMatches = (item: HolidayItem, grade: number): boolean => {
+  const key = GRADE_KEYS[grade];
+  return key ? item.gradeEventYn[key] === 'Y' : false;
+};
+
+export interface ScheduleEntry {
+  item: HolidayItem;
+  schoolGroupKey?: string;
+  childNames?: string[];
+}
+
+export const getHolidaysForDate = (commonHolidays: HolidayItem[], date: string): HolidayItem[] =>
+  commonHolidays.filter((h) => h.date === date);
+
+export const getAcademicSchedulesForDate = (
+  groups: SchoolGroup[],
+  date: string,
+  selectedChildId: number | undefined
+): ScheduleEntry[] => {
+  const result: ScheduleEntry[] = [];
+  const multiGroup = groups.length > 1;
+
+  if (selectedChildId === undefined) {
+    const seen = new Set<string>();
+    groups.forEach((group) => {
+      group.schedules
+        .filter((s) => s.date === date)
+        .forEach((s) => {
+          const anyMatch = group.children.some((c) => gradeMatches(s, c.grade));
+          const key = `${group.schoolGroupKey}:${s.date}:${s.eventName}`;
+          if (anyMatch && !seen.has(key)) {
+            seen.add(key);
+            const matchingNames = group.children
+              .filter((c) => gradeMatches(s, c.grade))
+              .map((c) => c.childName);
+            result.push({
+              item: s,
+              schoolGroupKey: multiGroup ? group.schoolGroupKey : undefined,
+              childNames: multiGroup ? matchingNames : undefined,
+            });
+          }
+        });
+    });
+  } else {
+    groups.forEach((group) => {
+      if (!group.childIds.includes(selectedChildId)) return;
+      const childInGroup = group.children.find((c) => c.childId === selectedChildId);
+      if (!childInGroup) return;
+      group.schedules
+        .filter((s) => s.date === date)
+        .forEach((s) => {
+          if (gradeMatches(s, childInGroup.grade)) result.push({ item: s });
+        });
+    });
+  }
+
+  return result;
+};
+
+export const getSchoolDotsForDate = (
+  commonHolidays: HolidayItem[],
+  groups: SchoolGroup[],
+  date: string
+): { key: string; color: string }[] => {
+  const hasAny =
+    commonHolidays.some((h) => h.date === date) ||
+    groups.some((g) => g.schedules.some((s) => s.date === date));
+  return hasAny ? [{ key: 'school', color: colors.gray[300] }] : [];
+};


### PR DESCRIPTION
## 📌 작업 내용

- 학사 일정 카드 구현 (공휴일/학사일정 구분)
- 해당 자녀 학년 Y인 학사일정만 표시, 해당하는 자녀만 태그
- 자녀 학교 학사일정 조회 GET /api/v1/calendars/school-schedules

## 📷 스크린 샷
<img width="300" src="https://github.com/user-attachments/assets/016edaa5-b5c4-40fa-8a5e-f0e7bf63ac60" />

<img width="300" src="https://github.com/user-attachments/assets/e2652c5f-1352-45e2-9a7b-0a0fc7dcdc07" />


## ⚠️ 참고 사항

## 🔗 관련 이슈

Closes #86 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 캘린더에 공휴일 및 학사일정 조회 기능 추가
  * 월간/주간/일간 캘린더 뷰에 학교 일정 정보 표시
  * 선택된 자녀별 학사일정 필터링 및 상세 정보 표시
  * 다국어 지원 (한국어, 영어, 베트남어)

* **스타일**
  * 프로필 카드 및 버튼 레이아웃 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->