### PR TITLE
✨ [Feature] 마이페이지 비밀번호 변경 API 연동 (#85)

### DIFF
--- a/app/profile/password.tsx
+++ b/app/profile/password.tsx
@@ -28,11 +28,18 @@ const ProfilePasswordScreen = () => {
   const [userInfoFetchFailed, setUserInfoFetchFailed] = useState(false);
   const isSubmitting = useRef(false);
 
-  const loadUserInfo = useCallback(() => {
+  const loadUserInfo = useCallback(async () => {
     setUserInfoFetchFailed(false);
-    fetchMyInfo()
-      .then(setUserInfo)
-      .catch(() => setUserInfoFetchFailed(true));
+    try {
+      const info = await fetchMyInfo();
+      setUserInfo(info);
+    } catch (error) {
+      if (error instanceof UserApiError && error.code === 'UNAUTHORIZED') {
+        router.replace('/(auth)/login');
+        return;
+      }
+      setUserInfoFetchFailed(true);
+    }
   }, []);
 
   useEffect(() => {

--- a/app/profile/password.tsx
+++ b/app/profile/password.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { View, ScrollView, StyleSheet, Alert } from 'react-native';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { View, Text, ScrollView, TouchableOpacity, StyleSheet, Alert } from 'react-native';
 import { router } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import Header from '../../src/components/common/Header';
@@ -7,8 +7,9 @@ import FormField from '../../src/components/auth/FormField';
 import PasswordStrengthBar, { getStrength } from '../../src/components/auth/PasswordStrengthBar';
 import { PrimaryButton } from '../../src/components/common/Button';
 import { validatePassword } from '../../src/validation/auth';
-import { fetchMyInfo, UserInfo } from '../../src/api/user';
+import { fetchMyInfo, UserInfo, changePassword, UserApiError } from '../../src/api/user';
 import colors from '../../src/constants/colors';
+import fonts from '../../src/constants/fonts';
 import layout from '../../src/constants/layout';
 
 const MIN_PASSWORD_STRENGTH = 2;
@@ -22,14 +23,21 @@ const ProfilePasswordScreen = () => {
   const [showCurrent, setShowCurrent] = useState(false);
   const [showNew, setShowNew] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [currentPasswordError, setCurrentPasswordError] = useState<string | undefined>(undefined);
+  const [userInfoFetchFailed, setUserInfoFetchFailed] = useState(false);
+  const isSubmitting = useRef(false);
 
-  useEffect(() => {
+  const loadUserInfo = useCallback(() => {
+    setUserInfoFetchFailed(false);
     fetchMyInfo()
       .then(setUserInfo)
-      .catch((e) => {
-        console.error('fetchMyInfo failed in password screen:', e);
-      });
+      .catch(() => setUserInfoFetchFailed(true));
   }, []);
+
+  useEffect(() => {
+    loadUserInfo();
+  }, [loadUserInfo]);
 
   const newPasswordError = (() => {
     if (!newPassword) return undefined;
@@ -45,6 +53,7 @@ const ProfilePasswordScreen = () => {
   })();
 
   const canSubmit =
+    userInfo !== null &&
     currentPassword.length > 0 &&
     newPassword.length > 0 &&
     newPasswordError === undefined &&
@@ -62,13 +71,27 @@ const ProfilePasswordScreen = () => {
         showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
       >
+        {userInfoFetchFailed && (
+          <TouchableOpacity style={styles.fetchErrorRow} onPress={loadUserInfo}>
+            <Text style={styles.fetchErrorText}>
+              {t('profile.editProfile.changePassword.userInfoFetchError')}
+            </Text>
+            <Text style={styles.retryText}>{t('common.retry')}</Text>
+          </TouchableOpacity>
+        )}
+
         <FormField
           label={t('profile.editProfile.changePassword.currentPassword')}
           value={currentPassword}
-          onChangeText={setCurrentPassword}
+          onChangeText={(text) => {
+            setCurrentPassword(text);
+            setCurrentPasswordError(undefined);
+          }}
           secureTextEntry={!showCurrent}
           rightIcon={showCurrent ? 'eye-outline' : 'eye-off-outline'}
           onRightIconPress={() => setShowCurrent((prev) => !prev)}
+          validationState={currentPasswordError ? 'error' : undefined}
+          validationMessage={currentPasswordError}
         />
 
         <FormField
@@ -108,13 +131,33 @@ const ProfilePasswordScreen = () => {
 
         <PrimaryButton
           label={t('profile.editProfile.changePassword.submit')}
-          onPress={() =>
-            Alert.alert(
-              t('common.preparing'),
-              t('profile.editProfile.changePassword.preparingMessage')
-            )
-          }
-          disabled={!canSubmit}
+          onPress={async () => {
+            if (isSubmitting.current) return;
+            isSubmitting.current = true;
+            setIsLoading(true);
+            try {
+              await changePassword({
+                currentPassword,
+                newPassword,
+                newPasswordConfirm: confirmPassword,
+              });
+              router.back();
+            } catch (error) {
+              if (error instanceof UserApiError && error.code === 'AUTH4011') {
+                setCurrentPasswordError(
+                  t('profile.editProfile.changePassword.errorCurrentPassword')
+                );
+              } else if (error instanceof UserApiError && error.code === 'UNAUTHORIZED') {
+                router.replace('/(auth)/login');
+              } else {
+                Alert.alert('', t('profile.editProfile.changePassword.errorGeneral'));
+              }
+            } finally {
+              setIsLoading(false);
+              isSubmitting.current = false;
+            }
+          }}
+          disabled={!canSubmit || isLoading}
         />
       </ScrollView>
     </View>
@@ -134,5 +177,26 @@ const styles = StyleSheet.create({
     paddingTop: 24,
     paddingBottom: 20,
     gap: 24,
+  },
+  fetchErrorRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    backgroundColor: colors.gray[100],
+    borderRadius: 8,
+  },
+  fetchErrorText: {
+    flex: 1,
+    fontSize: 13,
+    fontFamily: fonts.regular,
+    color: colors.text.red,
+  },
+  retryText: {
+    fontSize: 13,
+    fontFamily: fonts.semiBold,
+    color: colors.primary[400],
+    marginLeft: 8,
   },
 });

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -122,3 +122,23 @@ export const updateNotificationPreference = async (
     throw wrapError(error);
   }
 };
+
+export interface ChangePasswordPayload {
+  currentPassword: string;
+  newPassword: string;
+  newPasswordConfirm: string;
+}
+
+export const changePassword = async (payload: ChangePasswordPayload): Promise<void> => {
+  let responseData: { success?: boolean; code?: string; message?: string } | undefined;
+  try {
+    const headers = await getAuthHeader();
+    const { data } = await apiClient.patch('/api/v1/users/me/password', payload, { headers });
+    responseData = data;
+  } catch (error) {
+    throw wrapError(error);
+  }
+  if (responseData?.success === false) {
+    throw new UserApiError(responseData.code ?? 'UNKNOWN', responseData.message ?? '알 수 없는 오류');
+  }
+};

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -615,7 +615,10 @@
         "newPassword": "New Password",
         "confirmPassword": "Confirm New Password",
         "submit": "Change Password",
-        "preparingMessage": "Password change feature is coming soon."
+        "preparingMessage": "Password change feature is coming soon.",
+        "errorCurrentPassword": "Current password is incorrect.",
+        "errorGeneral": "Failed to change password. Please try again.",
+        "userInfoFetchError": "Failed to load user information."
       },
       "withdraw": "Withdraw",
       "withdrawTitle": "Are you sure you want to leave?",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -593,7 +593,10 @@
         "newPassword": "새 비밀번호",
         "confirmPassword": "새 비밀번호 확인",
         "submit": "비밀번호 변경",
-        "preparingMessage": "비밀번호 변경 기능은 현재 준비 중이에요."
+        "preparingMessage": "비밀번호 변경 기능은 현재 준비 중이에요.",
+        "errorCurrentPassword": "현재 비밀번호가 올바르지 않습니다.",
+        "errorGeneral": "비밀번호 변경에 실패했습니다. 다시 시도해주세요.",
+        "userInfoFetchError": "사용자 정보를 불러오지 못했습니다."
       },
       "withdraw": "탈퇴하기",
       "withdrawTitle": "정말 탈퇴하시겠어요?",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -615,7 +615,10 @@
         "newPassword": "Mật khẩu mới",
         "confirmPassword": "Xác nhận mật khẩu mới",
         "submit": "Thay đổi mật khẩu",
-        "preparingMessage": "Tính năng thay đổi mật khẩu hiện đang được chuẩn bị."
+        "preparingMessage": "Tính năng thay đổi mật khẩu hiện đang được chuẩn bị.",
+        "errorCurrentPassword": "Mật khẩu hiện tại không chính xác.",
+        "errorGeneral": "Thay đổi mật khẩu thất bại. Vui lòng thử lại.",
+        "userInfoFetchError": "Không thể tải thông tin người dùng."
       },
       "withdraw": "Hủy tài khoản",
       "withdrawTitle": "Bạn có chắc muốn hủy tài khoản không?",


### PR DESCRIPTION
## 📌 작업 내용

- 비밀번호 변경 API 연동 `PATCH /api/v1/users/me/password`

## 📷 스크린 샷
<img width="300" src="https://github.com/user-attachments/assets/8ec4f353-4c8b-4bee-95cb-308ce0f38f0e" />

## ⚠️ 참고 사항

-

## 🔗 관련 이슈

Closes #85 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 비밀번호 변경 기능이 추가되었습니다.
  * 현재 비밀번호 검증 및 오류 표시 기능이 추가되었습니다.
  * 사용자 정보 로딩 실패 시 재시도 기능이 추가되었습니다.

* **개선 사항**
  * 중복 제출 방지 기능이 적용되었습니다.
  * 에러 상황별 상세 메시지가 제공됩니다.

* **다국어 지원**
  * 비밀번호 변경 관련 오류 메시지가 영어, 한국어, 베트남어로 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->