### PR TITLE
♻️ [Refactor] 홈 화면 헤더 및 그라데이션 스크롤 구조 개선 (#95)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -10,10 +10,10 @@ import { useUserStore } from '../../src/store/userStore';
 import { fetchUnreadCount } from '../../src/api/notifications';
 import { useNotificationStore } from '../../src/store/notificationStore';
 import TaskCard from '../../src/components/home/TaskCard';
-import ScanBanner from '../../src/components/home/ScanBanner';
+// import ScanBanner from '../../src/components/home/ScanBanner';
 import FeatureSection from '../../src/components/home/FeatureSection';
 import MealTimetableWidget from '../../src/components/home/MealTimetableWidget';
-import GuideCards from '../../src/components/home/GuideCards';
+// import GuideCards from '../../src/components/home/GuideCards';
 import RecentDocs from '../../src/components/home/RecentDocs';
 import colors from '../../src/constants/colors';
 import styles from '../../src/styles/home/homeScreen';
@@ -56,37 +56,38 @@ const HomeScreen = () => {
 
   return (
     <View style={styles.screen}>
-      <View style={[styles.header, { paddingTop: insets.top + 16 }]}>
-        <View style={styles.headerInner}>
-          <View style={styles.headerTexts}>
-            <Text style={styles.greeting}>{greetingText}</Text>
-            <Text style={styles.username}>{t('home.usernameFormat', { name })}</Text>
+      <ScrollView showsVerticalScrollIndicator={false}>
+        <View>
+          <LinearGradient
+            colors={[colors.primary[200], colors.text.white]}
+            style={styles.gradient}
+          />
+          <View style={[styles.header, { paddingTop: insets.top + 16 }]}>
+            <View style={styles.headerInner}>
+              <View style={styles.headerTexts}>
+                <Text style={styles.greeting}>{greetingText}</Text>
+                <Text style={styles.username}>{t('home.usernameFormat', { name })}</Text>
+              </View>
+              <TouchableOpacity
+                style={styles.bellButton}
+                activeOpacity={0.7}
+                onPress={() => router.push('/notifications')}
+              >
+                <Ionicons name="notifications-outline" size={22} color={colors.primary[600]} />
+                {unreadCount > 0 && <View style={styles.badge} />}
+              </TouchableOpacity>
+            </View>
           </View>
-          <TouchableOpacity
-            style={styles.bellButton}
-            activeOpacity={0.7}
-            onPress={() => router.push('/notifications')}
-          >
-            <Ionicons name="notifications-outline" size={22} color={colors.primary[600]} />
-            {unreadCount > 0 && <View style={styles.badge} />}
-          </TouchableOpacity>
+          <View style={styles.scrollContent}>
+            <TaskCard />
+            {/* <ScanBanner /> */}
+            <FeatureSection />
+            <MealTimetableWidget />
+            {/* <GuideCards /> */}
+            <RecentDocs />
+          </View>
         </View>
-      </View>
-
-      <View style={styles.contentWrapper}>
-        <LinearGradient colors={[colors.primary[200], colors.text.white]} style={styles.gradient} />
-        <ScrollView
-          showsVerticalScrollIndicator={false}
-          contentContainerStyle={styles.scrollContent}
-        >
-          <TaskCard />
-          <ScanBanner />
-          <FeatureSection />
-          <MealTimetableWidget />
-          <GuideCards />
-          <RecentDocs />
-        </ScrollView>
-      </View>
+      </ScrollView>
     </View>
   );
 };

--- a/src/styles/home/homeScreen.ts
+++ b/src/styles/home/homeScreen.ts
@@ -9,7 +9,6 @@ const styles = StyleSheet.create({
     backgroundColor: colors.text.white,
   },
   header: {
-    backgroundColor: colors.primary[200],
     paddingHorizontal: layout.screenPaddingHorizontal,
     paddingBottom: 20,
   },
@@ -56,15 +55,12 @@ const styles = StyleSheet.create({
     borderRadius: 2,
     backgroundColor: colors.text.red,
   },
-  contentWrapper: {
-    flex: 1,
-  },
   gradient: {
     position: 'absolute',
     top: 0,
     left: 0,
     right: 0,
-    height: 350,
+    height: 500,
   },
   scrollContent: {
     paddingHorizontal: layout.screenPaddingHorizontal,


### PR DESCRIPTION
## 📌 작업 내용

- 홈 화면 헤더(인사말·이름·알림 아이콘)와 그라데이션을 ScrollView 내부로 이동하여 콘텐츠와 함께 스크롤되도록 구조 변경
- LinearGradient를 position: absolute 배경으로 재배치하여 카드 영역 뒤까지 자연스럽게 페이드 유지
- ScanBanner, GuideCards 컴포넌트 임시 비활성화

## 📷 스크린 샷

<img width="1080" height="2424" alt="Screenshot_1783756747" src="https://github.com/user-attachments/assets/39993414-b9a4-4b66-9430-5e7964040c45" />
<img width="1080" height="2424" alt="Screenshot_1783756754" src="https://github.com/user-attachments/assets/f395d680-a075-4034-a7eb-1d4ef5c2d052" />


## ⚠️ 참고 사항

- ScanBanner(가정통신문 스캔하기), GuideCards(궁금하셨나요?) 는 주석 처리된 상태로 추후 재활성화 필요

## 🔗 관련 이슈

Closes #95 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
  - 홈 화면에서 스캔 배너와 가이드 카드가 표시되지 않도록 변경되었습니다.
  - 홈 화면의 스크롤 및 콘텐츠 배치가 개선되어 그라데이션, 헤더, 본문이 자연스럽게 연결됩니다.
  - 배경색과 그라데이션 영역이 조정되어 화면의 시각적 구성이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->