### PR TITLE
♻️ [Refactor] 캘린더 화면 구조 및 반응형 UI 개선  (#97)

### DIFF
--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -1,6 +1,13 @@
 import { useState, useMemo, useRef, useEffect, useCallback } from 'react';
-import { View, Text, ScrollView, TouchableOpacity, ActivityIndicator } from 'react-native';
-import { FontAwesome5 } from '@expo/vector-icons';
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+  useWindowDimensions,
+} from 'react-native';
+import { FontAwesome5, Ionicons } from '@expo/vector-icons';
 import { useFocusEffect, useLocalSearchParams } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import colors from '../../src/constants/colors';
@@ -22,6 +29,7 @@ import {
   type HolidayItem,
   type SchoolGroup,
 } from '../../src/api/calendar';
+import { fetchChildren as fetchChildrenApi } from '../../src/api/child';
 import {
   getHolidaysForDate,
   getAcademicSchedulesForDate,
@@ -51,10 +59,12 @@ const formatWeekDateHeader = (dateStr: string, locale: string) => {
 
 const CalendarScreen = () => {
   const { t, i18n } = useTranslation();
-  const { children } = useChildrenStore();
+  const { height: windowHeight } = useWindowDimensions();
+  const { children, setChildren: setStoreChildren } = useChildrenStore();
   const [selectedChildName, setSelectedChildName] = useState<string | undefined>(undefined);
   const [selectedDate, setSelectedDate] = useState<string>(today);
   const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
+  const [showScrollTop, setShowScrollTop] = useState(false);
   const [monthlyMarkers, setMonthlyMarkers] = useState<MonthlyMarker[]>([]);
   const [dayEvents, setDayEvents] = useState<CalendarEvent[]>([]);
   const [weeklyData, setWeeklyData] = useState<WeeklyResult | null>(null);
@@ -86,10 +96,16 @@ const CalendarScreen = () => {
     useCallback(() => {
       if (!hasFocusedOnceRef.current) {
         hasFocusedOnceRef.current = true;
+        fetchChildrenApi()
+          .then(setStoreChildren)
+          .catch(() => {});
         return;
       }
+      fetchChildrenApi()
+        .then(setStoreChildren)
+        .catch(() => {});
       setFocusKey((k) => k + 1);
-    }, [])
+    }, [setStoreChildren])
   );
 
   const selectedChildId = useMemo(
@@ -97,11 +113,12 @@ const CalendarScreen = () => {
     [children, selectedChildName]
   );
 
-  const weekScrollRef = useRef<ScrollView>(null);
+  const scrollRef = useRef<ScrollView>(null);
   const weekOffsetRef = useRef(weekOffset);
   const shouldAutoScrollRef = useRef(weekOffset === 0);
   weekOffsetRef.current = weekOffset;
   const todayGroupY = useRef<number | undefined>(undefined);
+  const isFirstChildRenderRef = useRef(true);
   const weeklyReqIdRef = useRef(0);
   const monthlyReqIdRef = useRef(0);
   const dailyReqIdRef = useRef(0);
@@ -110,6 +127,15 @@ const CalendarScreen = () => {
   useEffect(() => {
     shouldAutoScrollRef.current = weekOffset === 0;
   }, [weekOffset]);
+
+  useEffect(() => {
+    if (isFirstChildRenderRef.current) {
+      isFirstChildRenderRef.current = false;
+      return;
+    }
+    scrollRef.current?.scrollTo({ y: 0, animated: true });
+    setShowScrollTop(false);
+  }, [selectedChildName]);
 
   const weekDates = useMemo(() => {
     const d = new Date();
@@ -357,6 +383,11 @@ const CalendarScreen = () => {
   const handleToggleMode = () => {
     setIsWeekMode((prev) => !prev);
     setExpandedIds(new Set());
+    setShowScrollTop(false);
+  };
+
+  const handleScroll = ({ nativeEvent }: { nativeEvent: { contentOffset: { y: number } } }) => {
+    setShowScrollTop(nativeEvent.contentOffset.y > windowHeight * 1.0);
   };
 
   const syncSelectedDateToMonth = (year: number, month: number) => {
@@ -411,7 +442,7 @@ const CalendarScreen = () => {
         />
       </View>
 
-      {/* 자녀 필터바 */}
+      {/* 자녀 필터바 - 고정 */}
       <ChildFilterBar
         items={children}
         selectedChildName={selectedChildName}
@@ -419,7 +450,21 @@ const CalendarScreen = () => {
       />
 
       {isWeekMode ? (
-        <>
+        <ScrollView
+          ref={scrollRef}
+          style={styles.scrollArea}
+          showsVerticalScrollIndicator={false}
+          onScroll={handleScroll}
+          scrollEventThrottle={100}
+          onContentSizeChange={() => {
+            if (weekOffsetRef.current !== 0 || !shouldAutoScrollRef.current) return;
+            requestAnimationFrame(() => {
+              if (weekOffsetRef.current !== 0 || todayGroupY.current === undefined) return;
+              scrollRef.current?.scrollTo({ y: todayGroupY.current, animated: false });
+              shouldAutoScrollRef.current = false;
+            });
+          }}
+        >
           {/* 주간 날짜 바 */}
           <WeekCalendar
             weekDates={weekDates}
@@ -431,68 +476,60 @@ const CalendarScreen = () => {
 
           {/* 주간 일정 목록 */}
           {isLoading ? (
-            <View style={styles.loadingContainer}>
+            <View style={styles.loadingContainerInline}>
               <ActivityIndicator size="large" color={colors.primary[400]} />
             </View>
           ) : (
-            <ScrollView
-              ref={weekScrollRef}
-              style={styles.list}
-              showsVerticalScrollIndicator={false}
-              onContentSizeChange={() => {
-                if (weekOffsetRef.current !== 0 || !shouldAutoScrollRef.current) return;
-                requestAnimationFrame(() => {
-                  if (weekOffsetRef.current !== 0 || todayGroupY.current === undefined) return;
-                  weekScrollRef.current?.scrollTo({ y: todayGroupY.current, animated: false });
-                  shouldAutoScrollRef.current = false;
-                });
-              }}
-            >
-              <View style={styles.weekListContent}>
-                {weekDisplayGroups.length === 0 ? (
-                  <Text style={styles.emptyText}>{t('calendar.emptyWeek')}</Text>
-                ) : (
-                  weekDisplayGroups.map((group) => (
-                    <View
-                      key={group.date}
-                      onLayout={(e) => {
-                        if (group.date === today) {
-                          todayGroupY.current = e.nativeEvent.layout.y;
-                        }
-                      }}
-                    >
-                      <Text style={styles.weekDateHeader}>
-                        {formatWeekDateHeader(group.date, i18n.language)}
-                      </Text>
-                      <View style={styles.cardGroup}>
-                        {group.schoolSchedules.map((entry) => (
-                          <SchoolScheduleRow
-                            key={`${entry.item.date}-${entry.item.eventName}-${entry.schoolGroupKey ?? entry.type}`}
-                            item={entry.item}
-                            type={entry.type}
-                            childNames={entry.childNames}
-                          />
-                        ))}
-                        {group.events.map((event) => (
-                          <EventCard
-                            key={event.eventId}
-                            event={event}
-                            expanded={expandedIds.has(event.eventId)}
-                            isPast={group.date < today}
-                            onToggleExpand={() => toggleExpand(event.eventId)}
-                            onToggleCheck={(checklistId) => toggleCheck(event.eventId, checklistId)}
-                          />
-                        ))}
-                      </View>
+            <View style={styles.weekListContent}>
+              {weekDisplayGroups.length === 0 ? (
+                <Text style={styles.emptyText}>{t('calendar.emptyWeek')}</Text>
+              ) : (
+                weekDisplayGroups.map((group) => (
+                  <View
+                    key={group.date}
+                    onLayout={(e) => {
+                      if (group.date === today) {
+                        todayGroupY.current = e.nativeEvent.layout.y;
+                      }
+                    }}
+                  >
+                    <Text style={styles.weekDateHeader}>
+                      {formatWeekDateHeader(group.date, i18n.language)}
+                    </Text>
+                    <View style={styles.cardGroup}>
+                      {group.schoolSchedules.map((entry) => (
+                        <SchoolScheduleRow
+                          key={`${entry.item.date}-${entry.item.eventName}-${entry.schoolGroupKey ?? entry.type}`}
+                          item={entry.item}
+                          type={entry.type}
+                          childNames={entry.childNames}
+                        />
+                      ))}
+                      {group.events.map((event) => (
+                        <EventCard
+                          key={event.eventId}
+                          event={event}
+                          expanded={expandedIds.has(event.eventId)}
+                          isPast={group.date < today}
+                          onToggleExpand={() => toggleExpand(event.eventId)}
+                          onToggleCheck={(checklistId) => toggleCheck(event.eventId, checklistId)}
+                        />
+                      ))}
                     </View>
-                  ))
-                )}
-              </View>
-            </ScrollView>
+                  </View>
+                ))
+              )}
+            </View>
           )}
-        </>
+        </ScrollView>
       ) : (
-        <>
+        <ScrollView
+          ref={scrollRef}
+          style={styles.scrollArea}
+          showsVerticalScrollIndicator={false}
+          onScroll={handleScroll}
+          scrollEventThrottle={100}
+        >
           {/* 월간 캘린더 */}
           <MonthCalendar
             year={calendarMonth.year}
@@ -506,42 +543,56 @@ const CalendarScreen = () => {
           />
 
           {/* 선택 날짜 + 일정 목록 */}
+          <Text style={styles.dayLabel}>{formatDayLabel(selectedDate, i18n.language)}</Text>
           {isLoading ? (
-            <View style={styles.loadingContainer}>
+            <View style={styles.loadingContainerInline}>
               <ActivityIndicator size="large" color={colors.primary[400]} />
             </View>
           ) : (
-            <ScrollView style={styles.list} showsVerticalScrollIndicator={false}>
-              <Text style={styles.dayLabel}>{formatDayLabel(selectedDate, i18n.language)}</Text>
-              <View style={styles.listContent}>
-                {isDailyLoading && <ActivityIndicator size="small" color={colors.primary[400]} />}
-                {!isDailyLoading && daySchoolSchedules.length === 0 && dayEvents.length === 0 && (
-                  <Text style={styles.emptyText}>{t('calendar.emptyDay')}</Text>
-                )}
-                {!isDailyLoading &&
-                  daySchoolSchedules.map((entry) => (
-                    <SchoolScheduleRow
-                      key={`${entry.item.date}-${entry.item.eventName}-${entry.schoolGroupKey ?? entry.type}`}
-                      item={entry.item}
-                      type={entry.type}
-                      childNames={entry.childNames}
-                    />
-                  ))}
-                {!isDailyLoading &&
-                  dayEvents.map((event) => (
-                    <EventCard
-                      key={event.eventId}
-                      event={event}
-                      expanded={expandedIds.has(event.eventId)}
-                      isPast={selectedDate < today}
-                      onToggleExpand={() => toggleExpand(event.eventId)}
-                      onToggleCheck={(checklistId) => toggleCheck(event.eventId, checklistId)}
-                    />
-                  ))}
-              </View>
-            </ScrollView>
+            <View style={styles.listContent}>
+              {isDailyLoading && <ActivityIndicator size="small" color={colors.primary[400]} />}
+              {!isDailyLoading && daySchoolSchedules.length === 0 && dayEvents.length === 0 && (
+                <Text style={styles.emptyText}>{t('calendar.emptyDay')}</Text>
+              )}
+              {!isDailyLoading &&
+                daySchoolSchedules.map((entry) => (
+                  <SchoolScheduleRow
+                    key={`${entry.item.date}-${entry.item.eventName}-${entry.schoolGroupKey ?? entry.type}`}
+                    item={entry.item}
+                    type={entry.type}
+                    childNames={entry.childNames}
+                  />
+                ))}
+              {!isDailyLoading &&
+                dayEvents.map((event) => (
+                  <EventCard
+                    key={event.eventId}
+                    event={event}
+                    expanded={expandedIds.has(event.eventId)}
+                    isPast={selectedDate < today}
+                    onToggleExpand={() => toggleExpand(event.eventId)}
+                    onToggleCheck={(checklistId) => toggleCheck(event.eventId, checklistId)}
+                  />
+                ))}
+            </View>
           )}
-        </>
+        </ScrollView>
+      )}
+
+      {/* 플로팅 버튼 */}
+      {showScrollTop && (
+        <TouchableOpacity
+          style={styles.scrollTopButton}
+          onPress={() => {
+            scrollRef.current?.scrollTo({ y: 0, animated: true });
+            setShowScrollTop(false);
+          }}
+          activeOpacity={0.8}
+          accessibilityRole="button"
+          accessibilityLabel={t('calendar.scrollToTop')}
+        >
+          <Ionicons name="arrow-up" size={20} color={colors.text.white} />
+        </TouchableOpacity>
       )}
     </View>
   );

--- a/app/(tabs)/document.tsx
+++ b/app/(tabs)/document.tsx
@@ -1,13 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import {
-  View,
-  Text,
-  TextInput,
-  ScrollView,
-  TouchableOpacity,
-  StyleSheet,
-  ActivityIndicator,
-} from 'react-native';
+import { View, Text, TextInput, ScrollView, StyleSheet, ActivityIndicator } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter, useFocusEffect } from 'expo-router';
 import { useTranslation } from 'react-i18next';
@@ -19,6 +11,7 @@ import { useChildrenStore } from '../../src/store/childrenStore';
 import { fetchNewsletters, NewsletterItem } from '../../src/api/newsletter';
 import DocumentCard from '../../src/components/document/DocumentCard';
 import Header from '../../src/components/common/Header';
+import ChildFilterBar from '../../src/components/common/ChildFilterBar';
 
 const formatDate = (dateStr: string): string => {
   const d = new Date(dateStr);
@@ -152,44 +145,11 @@ const DocumentScreen = () => {
         />
       </View>
 
-      <ScrollView
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        style={styles.filterScroll}
-        contentContainerStyle={styles.filterContent}
-      >
-        <TouchableOpacity
-          style={[styles.filterBtn, selectedChildName === undefined && styles.filterBtnSelected]}
-          onPress={() => handleChildFilter(undefined)}
-          activeOpacity={0.7}
-        >
-          <Text
-            style={[
-              styles.filterText,
-              selectedChildName === undefined && styles.filterTextSelected,
-            ]}
-          >
-            {t('common.all')}
-          </Text>
-        </TouchableOpacity>
-
-        {children.map((child) => {
-          const selected = selectedChildName === child.name;
-          return (
-            <TouchableOpacity
-              key={child.id}
-              style={[styles.filterBtn, selected && styles.filterBtnSelected]}
-              onPress={() => handleChildFilter(child.name)}
-              activeOpacity={0.7}
-            >
-              <View style={[styles.childDot, { backgroundColor: child.colorCode }]} />
-              <Text style={[styles.filterText, selected && styles.filterTextSelected]}>
-                {child.name}
-              </Text>
-            </TouchableOpacity>
-          );
-        })}
-      </ScrollView>
+      <ChildFilterBar
+        items={children}
+        selectedChildName={selectedChildName}
+        onSelect={handleChildFilter}
+      />
 
       <ScrollView
         style={styles.list}
@@ -249,46 +209,8 @@ const styles = StyleSheet.create({
     color: colors.text.primary,
     padding: 0,
   },
-  filterScroll: {
-    flexGrow: 0,
-    flexShrink: 0,
-  },
   list: {
     flex: 1,
-  },
-  filterContent: {
-    gap: 8,
-    alignItems: 'center',
-    paddingHorizontal: layout.screenPaddingHorizontal,
-    paddingVertical: 16,
-  },
-  filterBtn: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    borderWidth: 1,
-    borderColor: colors.gray[200],
-    borderRadius: 20,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    backgroundColor: colors.text.white,
-    gap: 6,
-  },
-  filterBtnSelected: {
-    backgroundColor: colors.primary[500],
-    borderColor: colors.primary[500],
-  },
-  filterText: {
-    fontSize: 14,
-    fontFamily: fonts.semiBold,
-    color: colors.text.secondary,
-  },
-  filterTextSelected: {
-    color: colors.text.white,
-  },
-  childDot: {
-    width: 5,
-    height: 5,
-    borderRadius: 99,
   },
   emptyText: {
     textAlign: 'center',

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -32,11 +32,12 @@ const MonthCalendar = ({
 }: MonthCalendarProps) => {
   const { t, i18n } = useTranslation();
 
-  const dayNames = Array.from({ length: 7 }, (_, i) =>
-    new Intl.DateTimeFormat(i18n.language, { weekday: 'short' }).format(
+  const dayNames = Array.from({ length: 7 }, (_, i) => ({
+    key: i,
+    label: new Intl.DateTimeFormat(i18n.language, { weekday: 'narrow' }).format(
       new Date(REF_SUNDAY.getFullYear(), REF_SUNDAY.getMonth(), REF_SUNDAY.getDate() + i)
-    )
-  );
+    ),
+  }));
 
   const monthLabel = new Intl.DateTimeFormat(i18n.language, {
     year: 'numeric',
@@ -98,9 +99,11 @@ const MonthCalendar = ({
       </View>
 
       <View style={styles.weekRow}>
-        {dayNames.map((name) => (
-          <View key={name} style={styles.dayCell}>
-            <Text style={styles.dayName}>{name}</Text>
+        {dayNames.map((day) => (
+          <View key={day.key} style={styles.dayCell}>
+            <Text style={styles.dayName} numberOfLines={1} maxFontSizeMultiplier={1.2}>
+              {day.label}
+            </Text>
           </View>
         ))}
       </View>
@@ -132,6 +135,8 @@ const MonthCalendar = ({
                       !inMonth && styles.outsideText,
                       isToday && styles.todayText,
                     ]}
+                    numberOfLines={1}
+                    maxFontSizeMultiplier={1.2}
                   >
                     {day}
                   </Text>
@@ -167,6 +172,8 @@ const styles = StyleSheet.create({
     marginHorizontal: 16,
   },
   headerText: {
+    flex: 1,
+    textAlign: 'center',
     fontSize: 14,
     fontFamily: fonts.medium,
     color: '#1A1A1A',

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -32,12 +32,15 @@ const MonthCalendar = ({
 }: MonthCalendarProps) => {
   const { t, i18n } = useTranslation();
 
-  const dayNames = Array.from({ length: 7 }, (_, i) => ({
-    key: i,
-    label: new Intl.DateTimeFormat(i18n.language, { weekday: 'narrow' }).format(
-      new Date(REF_SUNDAY.getFullYear(), REF_SUNDAY.getMonth(), REF_SUNDAY.getDate() + i)
-    ),
-  }));
+  const weekdayFormatter = new Intl.DateTimeFormat(i18n.language, { weekday: 'narrow' });
+  const dayNames = Array.from({ length: 7 }, (_, i) => {
+    const date = new Date(
+      REF_SUNDAY.getFullYear(),
+      REF_SUNDAY.getMonth(),
+      REF_SUNDAY.getDate() + i
+    );
+    return { key: date.getTime(), label: weekdayFormatter.format(date) };
+  });
 
   const monthLabel = new Intl.DateTimeFormat(i18n.language, {
     year: 'numeric',

--- a/src/components/calendar/WeekCalendar.tsx
+++ b/src/components/calendar/WeekCalendar.tsx
@@ -18,7 +18,7 @@ const WeekCalendar = ({ weekDates, today, markedDates, onPrev, onNext }: WeekCal
   const { t, i18n } = useTranslation();
 
   const dayNames = Array.from({ length: 7 }, (_, i) =>
-    new Intl.DateTimeFormat(i18n.language, { weekday: 'short' }).format(
+    new Intl.DateTimeFormat(i18n.language, { weekday: 'narrow' }).format(
       new Date(REF_SUNDAY.getFullYear(), REF_SUNDAY.getMonth(), REF_SUNDAY.getDate() + i)
     )
   );
@@ -62,9 +62,17 @@ const WeekCalendar = ({ weekDates, today, markedDates, onPrev, onNext }: WeekCal
 
           return (
             <View key={dateStr} style={styles.dayCell}>
-              <Text style={styles.dayName}>{dayNames[index]}</Text>
+              <Text style={styles.dayName} numberOfLines={1} maxFontSizeMultiplier={1.2}>
+                {dayNames[index]}
+              </Text>
               <View style={[styles.dateCircle, isToday && styles.todayCircle]}>
-                <Text style={[styles.dateText, isToday && styles.todayText]}>{day}</Text>
+                <Text
+                  style={[styles.dateText, isToday && styles.todayText]}
+                  numberOfLines={1}
+                  maxFontSizeMultiplier={1.2}
+                >
+                  {day}
+                </Text>
               </View>
               <View style={styles.dotsRow}>
                 {dots.slice(0, 4).map((dot) => (
@@ -96,6 +104,8 @@ const styles = StyleSheet.create({
     marginHorizontal: 16,
   },
   rangeText: {
+    flex: 1,
+    textAlign: 'center',
     fontSize: 14,
     fontFamily: fonts.medium,
     color: '#1A1A1A',

--- a/src/components/common/ChildFilterBar.tsx
+++ b/src/components/common/ChildFilterBar.tsx
@@ -36,6 +36,7 @@ const ChildFilterBar = ({ items, selectedChildName, onSelect }: ChildFilterBarPr
               styles.filterText,
               selectedChildName === undefined && styles.filterTextSelected,
             ]}
+            numberOfLines={1}
           >
             {t('common.all')}
           </Text>
@@ -50,7 +51,10 @@ const ChildFilterBar = ({ items, selectedChildName, onSelect }: ChildFilterBarPr
               activeOpacity={0.7}
             >
               <View style={[styles.filterDot, { backgroundColor: child.colorCode }]} />
-              <Text style={[styles.filterText, selected && styles.filterTextSelected]}>
+              <Text
+                style={[styles.filterText, selected && styles.filterTextSelected]}
+                numberOfLines={1}
+              >
                 {child.name}
               </Text>
             </TouchableOpacity>
@@ -65,7 +69,8 @@ export default ChildFilterBar;
 
 const styles = StyleSheet.create({
   filterBar: {
-    height: 53,
+    minHeight: 53,
+    paddingVertical: 11,
     backgroundColor: colors.text.white,
     justifyContent: 'center',
   },
@@ -77,8 +82,9 @@ const styles = StyleSheet.create({
   filterBtn: {
     flexDirection: 'row',
     alignItems: 'center',
-    height: 31,
-    borderRadius: 15,
+    minHeight: 31,
+    paddingVertical: 6,
+    borderRadius: 999,
     borderWidth: 1,
     borderColor: colors.gray[200],
     paddingHorizontal: 14,

--- a/src/components/common/SelectionCard.tsx
+++ b/src/components/common/SelectionCard.tsx
@@ -35,7 +35,7 @@ const SelectionCard = ({
     <TouchableOpacity
       style={[
         styles.card,
-        { height: s.height, paddingHorizontal: s.paddingH },
+        { minHeight: s.height, paddingHorizontal: s.paddingH },
         selected && styles.cardSelected,
       ]}
       onPress={onPress}
@@ -67,6 +67,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: colors.gray[200],
     borderRadius: 15,
+    paddingVertical: 14,
     gap: 14,
     overflow: 'hidden',
   },
@@ -91,6 +92,7 @@ const styles = StyleSheet.create({
   },
   content: {
     flex: 1,
+    minHeight: 0,
     gap: 2,
   },
   name: {
@@ -105,6 +107,7 @@ const styles = StyleSheet.create({
     width: 26,
     height: 26,
     borderRadius: 13,
+    flexShrink: 0,
     borderWidth: 1,
     borderColor: colors.gray[200],
     backgroundColor: colors.text.white,
@@ -118,5 +121,6 @@ const styles = StyleSheet.create({
     width: 8,
     height: 8,
     borderRadius: 4,
+    flexShrink: 0,
   },
 });

--- a/src/styles/calendar/calendar.ts
+++ b/src/styles/calendar/calendar.ts
@@ -27,15 +27,28 @@ export default StyleSheet.create({
     borderColor: colors.primary[400],
   },
 
-  // 로딩
-  loadingContainer: {
-    flex: 1,
+  loadingContainerInline: {
+    paddingVertical: 60,
     alignItems: 'center',
     justifyContent: 'center',
   },
-
-  // 일정 목록
-  list: {
+  scrollTopButton: {
+    position: 'absolute',
+    right: 20,
+    bottom: 24,
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: colors.primary[400],
+    alignItems: 'center',
+    justifyContent: 'center',
+    elevation: 4,
+    shadowColor: colors.text.primary,
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.15,
+    shadowRadius: 6,
+  },
+  scrollArea: {
     flex: 1,
   },
   dayLabel: {
@@ -85,23 +98,28 @@ export default StyleSheet.create({
   },
   cardHeader: {
     flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
+    alignItems: 'flex-start',
+    flexWrap: 'wrap',
+    rowGap: 6,
+    columnGap: 10,
     padding: 15,
   },
   cardLeft: {
     flex: 1,
+    minWidth: 100,
     gap: 6,
   },
   cardRight: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
+    flexShrink: 0,
   },
   cardTitle: {
     fontSize: 14,
     fontFamily: fonts.medium,
-    color: '#000000',
+    color: colors.text.primary,
+    lineHeight: 20,
   },
   cardTags: {
     flexDirection: 'row',
@@ -161,6 +179,7 @@ export default StyleSheet.create({
     justifyContent: 'center',
   },
   checkText: {
+    flex: 1,
     fontSize: 13,
     fontFamily: fonts.medium,
     color: '#000000',

--- a/src/styles/notifications/notifications.ts
+++ b/src/styles/notifications/notifications.ts
@@ -11,9 +11,9 @@ const styles = StyleSheet.create({
     backgroundColor: colors.text.white,
     paddingTop: 60,
   },
-
   dateLabelRow: {
-    height: 30,
+    minHeight: 30,
+    paddingVertical: 6,
     paddingHorizontal: 16,
     justifyContent: 'center',
   },
@@ -22,7 +22,6 @@ const styles = StyleSheet.create({
     fontFamily: fonts.medium,
     color: colors.text.secondary,
   },
-
   notifRowRead: {
     backgroundColor: colors.text.white,
     borderBottomWidth: 1,
@@ -43,7 +42,6 @@ const styles = StyleSheet.create({
     gap: 12,
     alignItems: 'flex-start',
   },
-
   iconBox: {
     width: 40,
     height: 40,
@@ -51,18 +49,20 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-
   textArea: {
     flex: 1,
   },
   notifTitleRow: {
     flexDirection: 'row',
+    flexWrap: 'wrap',
     justifyContent: 'space-between',
     alignItems: 'flex-start',
-    gap: 8,
+    rowGap: 2,
+    columnGap: 8,
   },
   notifTitle: {
     flex: 1,
+    minWidth: 0,
     fontSize: 14,
     fontFamily: fonts.medium,
     color: colors.text.primary,
@@ -71,6 +71,7 @@ const styles = StyleSheet.create({
     fontSize: 10,
     fontFamily: fonts.medium,
     color: colors.gray[200],
+    flexShrink: 0,
   },
   notifBody: {
     fontSize: 12,
@@ -79,7 +80,6 @@ const styles = StyleSheet.create({
     lineHeight: 16,
     marginTop: 2,
   },
-
   tagRow: {
     flexDirection: 'row',
     marginTop: 6,
@@ -88,8 +88,10 @@ const styles = StyleSheet.create({
     backgroundColor: colors.gray[100],
     borderRadius: 999,
     paddingHorizontal: 8,
-    height: 20,
+    minHeight: 20,
+    paddingVertical: 3,
     justifyContent: 'center',
+    alignItems: 'center',
   },
   childTagText: {
     fontSize: 11,

--- a/src/styles/profile/profile.ts
+++ b/src/styles/profile/profile.ts
@@ -32,6 +32,7 @@ const styles = StyleSheet.create({
   },
   profileInfo: {
     flex: 1,
+    minWidth: 0,
     gap: 4,
   },
   profileName: {
@@ -49,7 +50,8 @@ const styles = StyleSheet.create({
     backgroundColor: colors.gray[100],
     borderRadius: 999,
     paddingHorizontal: 7,
-    height: 21,
+    minHeight: 21,
+    paddingVertical: 3,
     justifyContent: 'center',
   },
   idBadgeText: {
@@ -68,6 +70,7 @@ const styles = StyleSheet.create({
     borderColor: colors.secondary[500],
     borderRadius: 999,
     minWidth: 52,
+    maxWidth: 90,
     flexShrink: 0,
     paddingHorizontal: 12,
     paddingVertical: 6,
@@ -78,6 +81,7 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontFamily: fonts.medium,
     color: colors.text.primary,
+    textAlign: 'center',
   },
   sectionLabel: {
     fontSize: 14,
@@ -95,16 +99,18 @@ const styles = StyleSheet.create({
     marginHorizontal: layout.screenPaddingHorizontal,
   },
   row: {
-    height: 52,
+    minHeight: 52,
     paddingHorizontal: 16,
+    paddingVertical: 14,
     flexDirection: 'row',
     alignItems: 'center',
     borderBottomWidth: 1,
     borderBottomColor: '#EEEEEE',
   },
   rowLast: {
-    height: 52,
+    minHeight: 52,
     paddingHorizontal: 16,
+    paddingVertical: 14,
     flexDirection: 'row',
     alignItems: 'center',
   },
@@ -121,8 +127,9 @@ const styles = StyleSheet.create({
     marginRight: 4,
   },
   childRow: {
-    height: 64,
+    minHeight: 64,
     paddingHorizontal: 16,
+    paddingVertical: 12,
     flexDirection: 'row',
     alignItems: 'center',
     gap: 12,
@@ -130,8 +137,9 @@ const styles = StyleSheet.create({
     borderBottomColor: '#EEEEEE',
   },
   childRowLast: {
-    height: 64,
+    minHeight: 64,
     paddingHorizontal: 16,
+    paddingVertical: 12,
     flexDirection: 'row',
     alignItems: 'center',
     gap: 12,

--- a/src/styles/profile/profileEdit.ts
+++ b/src/styles/profile/profileEdit.ts
@@ -48,8 +48,9 @@ const styles = StyleSheet.create({
     marginHorizontal: layout.screenPaddingHorizontal,
   },
   row: {
-    height: 52,
+    minHeight: 52,
     paddingHorizontal: 16,
+    paddingVertical: 14,
     flexDirection: 'row',
     alignItems: 'center',
   },

--- a/src/styles/profile/profileNotification.ts
+++ b/src/styles/profile/profileNotification.ts
@@ -33,7 +33,8 @@ export default StyleSheet.create({
     borderColor: colors.gray[200],
     marginHorizontal: layout.screenPaddingHorizontal,
     paddingHorizontal: 16,
-    height: 66,
+    minHeight: 66,
+    paddingVertical: 14,
     flexDirection: 'row',
     alignItems: 'center',
   },
@@ -128,14 +129,15 @@ export default StyleSheet.create({
   itemTitleRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 6,
+    flexWrap: 'wrap',
+    rowGap: 4,
+    columnGap: 6,
     flex: 1,
   },
   itemTitle: {
     fontSize: 14,
     fontFamily: fonts.semiBold,
     color: colors.text.primary,
-    flexShrink: 1,
   },
   itemDesc: {
     fontSize: 11,
@@ -149,10 +151,13 @@ export default StyleSheet.create({
   },
   // 뱃지
   badge: {
-    height: 21,
+    minHeight: 21,
+    paddingVertical: 4,
     borderRadius: 999,
     paddingHorizontal: 8,
     justifyContent: 'center',
+    alignItems: 'center',
+    flexShrink: 0,
   },
   badge_urgent: {
     backgroundColor: 'rgba(225,0,0,0.1)',

--- a/src/styles/register/language.ts
+++ b/src/styles/register/language.ts
@@ -44,6 +44,7 @@ const styles = StyleSheet.create({
     height: 50,
     borderRadius: 25,
     overflow: 'hidden',
+    flexShrink: 0,
   },
   flagImage: {
     width: 50,

--- a/src/styles/register/notification.ts
+++ b/src/styles/register/notification.ts
@@ -48,8 +48,9 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: colors.gray[200],
     borderRadius: 15,
-    height: 90,
+    minHeight: 90,
     paddingHorizontal: 20,
+    paddingVertical: 16,
     gap: 14,
     marginBottom: 10,
     overflow: 'hidden',
@@ -88,12 +89,15 @@ const styles = StyleSheet.create({
   // 카드 콘텐츠
   cardContent: {
     flex: 1,
+    minWidth: 0,
     gap: 4,
   },
   cardTitleRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 6,
+    flexWrap: 'wrap',
+    rowGap: 4,
+    columnGap: 6,
   },
   cardTitle: {
     fontSize: 16,
@@ -105,6 +109,7 @@ const styles = StyleSheet.create({
     borderRadius: 6,
     paddingHorizontal: 8,
     paddingVertical: 2,
+    flexShrink: 0,
   },
   badgeText: {
     fontSize: 12,
@@ -128,6 +133,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: colors.gray[200],
     backgroundColor: colors.text.white,
+    flexShrink: 0,
   },
   radioSelected: {
     backgroundColor: colors.primary[0],


### PR DESCRIPTION
## 📌 작업 내용

- 시스템 글자 및 디스플레이 크기에 대응하도록 화면 레이아웃 개선
- 캘린더와 일정 목록이 함께 스크롤되도록 구조 변경
- 일정 이상 스크롤 시 최상단 이동 버튼 추가
- `document.tsx` 자녀 필터를 공용 `ChildFilterBar` 컴포넌트로 통합

## 📷 스크린 샷
<img width="300" src="https://github.com/user-attachments/assets/aef348a8-e4ac-499b-978b-7f25c563f1ca" />


## ⚠️ 참고 사항

-

## 🔗 관련 이슈

Closes #97 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 캘린더에서 긴 일정 목록을 확인한 뒤 상단으로 바로 이동할 수 있습니다.
  * 자녀 선택 필터를 캘린더와 문서 화면에서 일관된 형태로 사용할 수 있습니다.
  * 일정 로딩 및 빈 상태가 화면 흐름에 맞게 표시됩니다.

* **개선 사항**
  * 주간·월간 캘린더의 자동 스크롤과 오늘 날짜 표시가 개선되었습니다.
  * 요일 및 날짜 표시가 더 간결하고 안정적으로 정렬됩니다.
  * 프로필, 알림, 등록 화면의 긴 텍스트와 버튼 레이아웃이 다양한 화면 크기에 맞게 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->