### PR TITLE
✨ [Feature] 문화 맥락 안내 API 연동 (#103)

### DIFF
--- a/src/api/newsletter.ts
+++ b/src/api/newsletter.ts
@@ -263,6 +263,26 @@ export const getConversationTopics = async (newsletterId: number): Promise<Conve
   }
 };
 
+export interface CulturalGuide {
+  faqId: number;
+  category: string;
+  question: string;
+  answer: string;
+}
+
+export const getCulturalGuides = async (newsletterId: number): Promise<CulturalGuide[]> => {
+  try {
+    const headers = await getAuthHeader();
+    const response = await apiClient.get<{ result: { guides: CulturalGuide[] } }>(
+      `/api/v1/newsletters/${newsletterId}/cultural-guides`,
+      { headers }
+    );
+    return response.data.result.guides ?? [];
+  } catch (error) {
+    throw wrapError(error);
+  }
+};
+
 export const fetchNewsletters = async (params: {
   childName?: string;
   search?: string;

--- a/src/components/scan/result/AISummaryTab.tsx
+++ b/src/components/scan/result/AISummaryTab.tsx
@@ -1,15 +1,22 @@
-import React, { useEffect, useState } from 'react';
-import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
+import { useEffect, useState } from 'react';
+import { View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import SummaryCard from './SummaryCard';
+import SummarySectionContent from './SummarySectionContent';
+import TopicListContent from './TopicListContent';
+import CulturalGuideList from './CulturalGuideList';
 import {
   getNewsletterSummary,
   getConversationTopics,
+  getCulturalGuides,
   NewsletterApiError,
 } from '../../../api/newsletter';
-import type { NewsletterSummaryResult, ConversationTopic } from '../../../api/newsletter';
+import type {
+  NewsletterSummaryResult,
+  ConversationTopic,
+  CulturalGuide,
+} from '../../../api/newsletter';
 import colors from '../../../constants/colors';
-import fonts from '../../../constants/fonts';
 
 interface Props {
   newsletterId?: number;
@@ -27,6 +34,7 @@ const mapSummaryErrorKey = (e: unknown): string => {
 
 const AISummaryTab = ({ newsletterId }: Props) => {
   const { t } = useTranslation();
+
   const [summary, setSummary] = useState<NewsletterSummaryResult | null>(null);
   const [summaryLoading, setSummaryLoading] = useState(true);
   const [summaryError, setSummaryError] = useState<string | null>(null);
@@ -35,6 +43,9 @@ const AISummaryTab = ({ newsletterId }: Props) => {
   const [topicsLoading, setTopicsLoading] = useState(true);
   const [topicsError, setTopicsError] = useState<string | null>(null);
 
+  const [guides, setGuides] = useState<CulturalGuide[]>([]);
+  const [guidesLoading, setGuidesLoading] = useState(true);
+
   useEffect(() => {
     setSummary(null);
     setSummaryLoading(true);
@@ -42,12 +53,15 @@ const AISummaryTab = ({ newsletterId }: Props) => {
     setTopics([]);
     setTopicsLoading(true);
     setTopicsError(null);
+    setGuides([]);
+    setGuidesLoading(true);
 
     if (!newsletterId) {
       setSummaryError('scan.result.aiSummary.error.notFound');
       setSummaryLoading(false);
       setTopicsError('scan.result.aiSummary.error.notFound');
       setTopicsLoading(false);
+      setGuidesLoading(false);
       return () => {};
     }
 
@@ -86,46 +100,21 @@ const AISummaryTab = ({ newsletterId }: Props) => {
         if (!cancelled) setTopicsLoading(false);
       });
 
+    getCulturalGuides(newsletterId)
+      .then((data) => {
+        if (!cancelled) setGuides(data);
+      })
+      .catch(() => {
+        if (!cancelled) setGuides([]);
+      })
+      .finally(() => {
+        if (!cancelled) setGuidesLoading(false);
+      });
+
     return () => {
       cancelled = true;
     };
   }, [newsletterId]);
-
-  const qnaItems = t('scan.result.aiSummary.qna', { returnObjects: true }) as Array<{
-    q: string;
-    a: string;
-    aHighlight: string;
-    aTail: string;
-  }>;
-
-  const renderSummary = () => {
-    if (summaryLoading) return <ActivityIndicator size="small" color={colors.primary[400]} />;
-    if (summaryError) return <Text style={styles.errorText}>{t(summaryError)}</Text>;
-    if (summary)
-      return (
-        <>
-          <Text style={styles.summaryTitle}>{summary.title}</Text>
-          <Text style={styles.body}>{summary.summary}</Text>
-        </>
-      );
-    return null;
-  };
-
-  const renderTopics = () => {
-    if (topicsLoading) return <ActivityIndicator size="small" color={colors.primary[400]} />;
-    if (topicsError) return <Text style={styles.errorText}>{t(topicsError)}</Text>;
-    if (topics.length === 0)
-      return <Text style={styles.errorText}>{t('scan.result.aiSummary.conversationEmpty')}</Text>;
-    return (
-      <View style={styles.topicList}>
-        {topics.map((item) => (
-          <View key={item.topicId} style={styles.topicBubble}>
-            <Text style={styles.topicText}>{item.topic}</Text>
-          </View>
-        ))}
-      </View>
-    );
-  };
 
   return (
     <View style={styles.list}>
@@ -134,7 +123,7 @@ const AISummaryTab = ({ newsletterId }: Props) => {
         iconBg={colors.primary[400]}
         title={t('scan.result.aiSummary.summarySection')}
       >
-        {renderSummary()}
+        <SummarySectionContent loading={summaryLoading} error={summaryError} summary={summary} />
       </SummaryCard>
 
       <SummaryCard
@@ -142,33 +131,18 @@ const AISummaryTab = ({ newsletterId }: Props) => {
         iconBg={colors.secondary[500]}
         title={t('scan.result.aiSummary.conversationTitle')}
       >
-        {renderTopics()}
+        <TopicListContent loading={topicsLoading} error={topicsError} topics={topics} />
       </SummaryCard>
 
-      <SummaryCard
-        icon="earth-outline"
-        iconBg={colors.primary[400]}
-        title={t('scan.result.aiSummary.culturalContext')}
-      >
-        <View style={styles.qnaList}>
-          {qnaItems.map((item) => (
-            <View key={item.q} style={styles.qnaItem}>
-              <View style={styles.qnaRow}>
-                <Text style={styles.qLabel}>Q.</Text>
-                <Text style={styles.qText}>{item.q}</Text>
-              </View>
-              <View style={styles.qnaRow}>
-                <Text style={styles.aLabel}>A.</Text>
-                <Text style={styles.aText}>
-                  {item.a}
-                  <Text style={styles.aHighlight}>{item.aHighlight}</Text>
-                  {item.aTail}
-                </Text>
-              </View>
-            </View>
-          ))}
-        </View>
-      </SummaryCard>
+      {(guidesLoading || guides.length > 0) && (
+        <SummaryCard
+          icon="earth-outline"
+          iconBg={colors.primary[400]}
+          title={t('scan.result.aiSummary.culturalContext')}
+        >
+          <CulturalGuideList loading={guidesLoading} guides={guides} />
+        </SummaryCard>
+      )}
     </View>
   );
 };
@@ -178,79 +152,5 @@ export default AISummaryTab;
 const styles = StyleSheet.create({
   list: {
     gap: 16,
-  },
-  summaryTitle: {
-    fontSize: 15,
-    fontFamily: fonts.semiBold,
-    color: colors.text.primary,
-  },
-  body: {
-    fontSize: 14,
-    fontFamily: fonts.regular,
-    color: colors.text.primary,
-    lineHeight: 22,
-  },
-  errorText: {
-    fontSize: 14,
-    fontFamily: fonts.medium,
-    color: colors.text.secondary,
-  },
-  topicList: {
-    gap: 10,
-  },
-  topicBubble: {
-    backgroundColor: colors.secondary[200],
-    borderWidth: 1,
-    borderColor: colors.secondary[500],
-    borderRadius: 16,
-    borderBottomLeftRadius: 0,
-    padding: 12,
-  },
-  topicText: {
-    fontSize: 14,
-    fontFamily: fonts.regular,
-    color: colors.text.primary,
-    lineHeight: 22,
-  },
-  qnaList: {
-    gap: 16,
-  },
-  qnaItem: {
-    gap: 6,
-  },
-  qnaRow: {
-    flexDirection: 'row',
-    gap: 8,
-    alignItems: 'flex-start',
-  },
-  qLabel: {
-    fontSize: 14,
-    fontFamily: fonts.bold,
-    color: colors.primary[500],
-    minWidth: 18,
-  },
-  aLabel: {
-    fontSize: 14,
-    fontFamily: fonts.bold,
-    color: colors.text.secondary,
-    minWidth: 18,
-  },
-  qText: {
-    flex: 1,
-    fontSize: 14,
-    fontFamily: fonts.semiBold,
-    color: colors.text.primary,
-    lineHeight: 22,
-  },
-  aText: {
-    flex: 1,
-    fontSize: 14,
-    fontFamily: fonts.regular,
-    color: colors.text.secondary,
-    lineHeight: 22,
-  },
-  aHighlight: {
-    fontFamily: fonts.bold,
-    color: colors.text.primary,
   },
 });

--- a/src/components/scan/result/CulturalGuideList.tsx
+++ b/src/components/scan/result/CulturalGuideList.tsx
@@ -1,0 +1,71 @@
+import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
+import type { CulturalGuide } from '../../../api/newsletter';
+import colors from '../../../constants/colors';
+import fonts from '../../../constants/fonts';
+
+interface Props {
+  loading: boolean;
+  guides: CulturalGuide[];
+}
+
+const CulturalGuideList = ({ loading, guides }: Props) => {
+  if (loading) return <ActivityIndicator size="small" color={colors.primary[400]} />;
+  return (
+    <View style={styles.qnaList}>
+      {guides.map((guide) => (
+        <View key={guide.faqId} style={styles.qnaItem}>
+          <View style={styles.qnaRow}>
+            <Text style={styles.qLabel}>Q.</Text>
+            <Text style={styles.qText}>{guide.question}</Text>
+          </View>
+          <View style={styles.qnaRow}>
+            <Text style={styles.aLabel}>A.</Text>
+            <Text style={styles.aText}>{guide.answer}</Text>
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+};
+
+export default CulturalGuideList;
+
+const styles = StyleSheet.create({
+  qnaList: {
+    gap: 16,
+  },
+  qnaItem: {
+    gap: 6,
+  },
+  qnaRow: {
+    flexDirection: 'row',
+    gap: 8,
+    alignItems: 'flex-start',
+  },
+  qLabel: {
+    fontSize: 14,
+    fontFamily: fonts.bold,
+    color: colors.primary[500],
+    minWidth: 18,
+  },
+  aLabel: {
+    fontSize: 14,
+    fontFamily: fonts.bold,
+    color: colors.text.secondary,
+    minWidth: 18,
+  },
+  qText: {
+    flex: 1,
+    fontSize: 14,
+    fontFamily: fonts.semiBold,
+    color: colors.text.primary,
+    lineHeight: 22,
+  },
+  aText: {
+    flex: 1,
+    fontSize: 14,
+    fontFamily: fonts.regular,
+    color: colors.text.secondary,
+    lineHeight: 22,
+  },
+});

--- a/src/components/scan/result/SummarySectionContent.tsx
+++ b/src/components/scan/result/SummarySectionContent.tsx
@@ -1,0 +1,49 @@
+import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import type { NewsletterSummaryResult } from '../../../api/newsletter';
+import colors from '../../../constants/colors';
+import fonts from '../../../constants/fonts';
+
+interface Props {
+  loading: boolean;
+  error: string | null;
+  summary: NewsletterSummaryResult | null;
+}
+
+const SummarySectionContent = ({ loading, error, summary }: Props) => {
+  const { t } = useTranslation();
+  if (loading) return <ActivityIndicator size="small" color={colors.primary[400]} />;
+  if (error) return <Text style={styles.errorText}>{t(error)}</Text>;
+  if (summary)
+    return (
+      <View style={styles.container}>
+        <Text style={styles.summaryTitle}>{summary.title}</Text>
+        <Text style={styles.body}>{summary.summary}</Text>
+      </View>
+    );
+  return null;
+};
+
+export default SummarySectionContent;
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 6,
+  },
+  summaryTitle: {
+    fontSize: 15,
+    fontFamily: fonts.semiBold,
+    color: colors.text.primary,
+  },
+  body: {
+    fontSize: 14,
+    fontFamily: fonts.regular,
+    color: colors.text.primary,
+    lineHeight: 22,
+  },
+  errorText: {
+    fontSize: 14,
+    fontFamily: fonts.medium,
+    color: colors.text.secondary,
+  },
+});

--- a/src/components/scan/result/TopicListContent.tsx
+++ b/src/components/scan/result/TopicListContent.tsx
@@ -1,0 +1,55 @@
+import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import type { ConversationTopic } from '../../../api/newsletter';
+import colors from '../../../constants/colors';
+import fonts from '../../../constants/fonts';
+
+interface Props {
+  loading: boolean;
+  error: string | null;
+  topics: ConversationTopic[];
+}
+
+const TopicListContent = ({ loading, error, topics }: Props) => {
+  const { t } = useTranslation();
+  if (loading) return <ActivityIndicator size="small" color={colors.primary[400]} />;
+  if (error) return <Text style={styles.errorText}>{t(error)}</Text>;
+  if (topics.length === 0)
+    return <Text style={styles.errorText}>{t('scan.result.aiSummary.conversationEmpty')}</Text>;
+  return (
+    <View style={styles.topicList}>
+      {topics.map((item) => (
+        <View key={item.topicId} style={styles.topicBubble}>
+          <Text style={styles.topicText}>{item.topic}</Text>
+        </View>
+      ))}
+    </View>
+  );
+};
+
+export default TopicListContent;
+
+const styles = StyleSheet.create({
+  topicList: {
+    gap: 10,
+  },
+  topicBubble: {
+    backgroundColor: colors.secondary[200],
+    borderWidth: 1,
+    borderColor: colors.secondary[500],
+    borderRadius: 16,
+    borderBottomLeftRadius: 0,
+    padding: 12,
+  },
+  topicText: {
+    fontSize: 14,
+    fontFamily: fonts.regular,
+    color: colors.text.primary,
+    lineHeight: 22,
+  },
+  errorText: {
+    fontSize: 14,
+    fontFamily: fonts.medium,
+    color: colors.text.secondary,
+  },
+});


### PR DESCRIPTION
## 📌 작업 내용

- `GET /api/v1/newsletters/{newsletterId}/cultural-guides` API 연동
- AI 요약 탭 내 문화 맥락 안내 섹션을 API 데이터로 교체 (기존 하드코딩 제거)
- 관련 FAQ가 없으면 해당 섹션 미노출 처리
- AISummaryTab 내 렌더 로직을 SummarySectionContent, TopicListContent, CulturalGuideList로 분리

## 📷 스크린 샷

-

## ⚠️ 참고 사항

- 문화 맥락 안내는 최대 2개 반환, API 오류 시에도 빈 배열로 처리해 섹션 미노출

## 🔗 관련 이슈

Closes #103


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 스캔 결과에 문화적 맥락 가이드 섹션이 추가되었습니다.
  - 가이드별 질문과 답변을 확인할 수 있습니다.
- **개선 사항**
  - 요약과 대화 주제 목록의 로딩 및 오류 상태 표시가 개선되었습니다.
  - 대화 주제가 없을 때 안내 메시지가 표시됩니다.
  - 요약, 대화 주제, 문화 가이드가 일관된 형식으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->