### PR TITLE
✨ [Feature] 챗봇 DOCUMENT 모드 연동 및 AI와 대화하기 연결 (#107)

### DIFF
--- a/app/chat/index.tsx
+++ b/app/chat/index.tsx
@@ -88,7 +88,9 @@ const ChatScreen = () => {
     newsletterId?: string;
   }>();
   const chatType = chatTypeParam === 'DOCUMENT' ? 'DOCUMENT' : 'GENERAL';
-  const newsletterId = newsletterIdParam ? Number(newsletterIdParam) : undefined;
+  const parsedNewsletterId = Number(newsletterIdParam);
+  const newsletterId =
+    Number.isInteger(parsedNewsletterId) && parsedNewsletterId > 0 ? parsedNewsletterId : undefined;
 
   const [messages, setMessages] = useState<ChatMessage[]>([
     {
@@ -149,12 +151,35 @@ const ChatScreen = () => {
       setMessages((prev) => [...prev, aiMessage]);
     } catch (error) {
       let errorContent = t('chat.errorMessage');
-      if (error instanceof ChatApiError) {
-        if (error.code === 'CHAT4003') {
-          sessionIdRef.current = null;
-        } else if (error.code === 'NL4004') {
-          errorContent = t('chat.nlNotReadyError');
+      if (error instanceof ChatApiError && error.code === 'CHAT4003') {
+        sessionIdRef.current = null;
+        try {
+          const retryResult = await sendChatMessage({
+            sessionId: null,
+            message: userMessage.content,
+            chatType,
+            newsletterId,
+          });
+          sessionIdRef.current = retryResult.sessionId;
+          const retryTimeStr = (() => {
+            const d = new Date(retryResult.sentAt);
+            return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+          })();
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: String(Date.now() + 1),
+              role: 'assistant',
+              content: retryResult.reply,
+              timestamp: retryTimeStr,
+            },
+          ]);
+          return;
+        } catch {
+          // 재시도도 실패하면 일반 오류 메시지 표시
         }
+      } else if (error instanceof ChatApiError && error.code === 'NL4004') {
+        errorContent = t('chat.nlNotReadyError');
       }
       const errorMessage: ChatMessage = {
         id: String(Date.now() + 1),

--- a/app/chat/index.tsx
+++ b/app/chat/index.tsx
@@ -11,13 +11,13 @@ import {
 } from 'react-native';
 import { Ionicons, Feather } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
-import { router } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import { useState, useRef, useEffect } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import colors from '../../src/constants/colors';
 import layout from '../../src/constants/layout';
 import styles from '../../src/styles/chat/chatScreen';
-import { sendChatMessage } from '../../src/api/chat';
+import { sendChatMessage, ChatApiError } from '../../src/api/chat';
 
 type MessageRole = 'user' | 'assistant';
 
@@ -83,11 +83,19 @@ const ChatScreen = () => {
   const insets = useSafeAreaInsets();
   const flatListRef = useRef<FlatList<ChatMessage>>(null);
 
+  const { chatType: chatTypeParam, newsletterId: newsletterIdParam } = useLocalSearchParams<{
+    chatType?: string;
+    newsletterId?: string;
+  }>();
+  const chatType = chatTypeParam === 'DOCUMENT' ? 'DOCUMENT' : 'GENERAL';
+  const newsletterId = newsletterIdParam ? Number(newsletterIdParam) : undefined;
+
   const [messages, setMessages] = useState<ChatMessage[]>([
     {
       id: 'welcome',
       role: 'assistant',
-      content: t('chat.welcomeMessage'),
+      content:
+        chatType === 'DOCUMENT' ? t('chat.documentWelcomeMessage') : t('chat.welcomeMessage'),
       timestamp: getTimeStr(),
     },
   ]);
@@ -120,7 +128,8 @@ const ChatScreen = () => {
       const result = await sendChatMessage({
         sessionId: sessionIdRef.current,
         message: userMessage.content,
-        chatType: 'GENERAL',
+        chatType,
+        newsletterId,
       });
 
       sessionIdRef.current = result.sessionId;
@@ -138,11 +147,19 @@ const ChatScreen = () => {
       };
 
       setMessages((prev) => [...prev, aiMessage]);
-    } catch {
+    } catch (error) {
+      let errorContent = t('chat.errorMessage');
+      if (error instanceof ChatApiError) {
+        if (error.code === 'CHAT4003') {
+          sessionIdRef.current = null;
+        } else if (error.code === 'NL4004') {
+          errorContent = t('chat.nlNotReadyError');
+        }
+      }
       const errorMessage: ChatMessage = {
         id: String(Date.now() + 1),
         role: 'assistant',
-        content: t('chat.errorMessage'),
+        content: errorContent,
         timestamp: getTimeStr(),
       };
       setMessages((prev) => [...prev, errorMessage]);

--- a/app/scan/result.tsx
+++ b/app/scan/result.tsx
@@ -93,6 +93,12 @@ const ScanResultScreen = () => {
           activeOpacity={0.8}
           accessibilityRole="button"
           accessibilityLabel={t('scan.result.chat')}
+          onPress={() =>
+            router.push({
+              pathname: '/chat',
+              params: { chatType: 'DOCUMENT', newsletterId: String(newsletterId) },
+            })
+          }
         >
           <Text style={styles.btnIcon} allowFontScaling={false}>
             💬

--- a/app/scan/result.tsx
+++ b/app/scan/result.tsx
@@ -93,12 +93,13 @@ const ScanResultScreen = () => {
           activeOpacity={0.8}
           accessibilityRole="button"
           accessibilityLabel={t('scan.result.chat')}
-          onPress={() =>
+          onPress={() => {
+            if (!newsletterId || !Number.isInteger(newsletterId) || newsletterId <= 0) return;
             router.push({
               pathname: '/chat',
               params: { chatType: 'DOCUMENT', newsletterId: String(newsletterId) },
-            })
-          }
+            });
+          }}
         >
           <Text style={styles.btnIcon} allowFontScaling={false}>
             💬

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -34,6 +34,7 @@ export interface SendMessageParams {
   sessionId: string | null;
   message: string;
   chatType?: 'GENERAL' | 'DOCUMENT';
+  newsletterId?: number;
 }
 
 export interface ChatResponse {
@@ -51,6 +52,7 @@ export const sendChatMessage = async (params: SendMessageParams): Promise<ChatRe
         sessionId: params.sessionId,
         message: params.message,
         chatType: params.chatType ?? 'GENERAL',
+        ...(params.newsletterId !== undefined && { newsletterId: params.newsletterId }),
       },
       { headers }
     );

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -52,7 +52,9 @@ export const sendChatMessage = async (params: SendMessageParams): Promise<ChatRe
         sessionId: params.sessionId,
         message: params.message,
         chatType: params.chatType ?? 'GENERAL',
-        ...(params.newsletterId !== undefined && { newsletterId: params.newsletterId }),
+        ...(params.newsletterId !== undefined &&
+          Number.isInteger(params.newsletterId) &&
+          params.newsletterId > 0 && { newsletterId: params.newsletterId }),
       },
       { headers }
     );

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -419,7 +419,8 @@
       "tabs": {
         "full": "Full Document",
         "checklist": "Checklist",
-        "aiSummary": "AI Summary"
+        "aiSummary": "AI Summary",
+        "chat": "Ask AI"
       },
       "chat": "Chat with AI",
       "save": "Save",
@@ -906,7 +907,9 @@
     "placeholder": "Type your question here",
     "typing": "Kachi is typing...",
     "today": "Today",
-    "errorMessage": "Sorry, an error occurred. Please try again. 🐦"
+    "errorMessage": "Sorry, an error occurred. Please try again. 🐦",
+    "documentWelcomeMessage": "Ask me anything about this newsletter! 🐦\nI'll answer based on the document content.",
+    "nlNotReadyError": "Document analysis is not complete yet. Please try again in a moment. 🐦"
   },
   "mealTimetable": {
     "sectionTitle": "Meals & Timetable",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -419,7 +419,8 @@
       "tabs": {
         "full": "전체 문서",
         "checklist": "체크리스트",
-        "aiSummary": "AI 요약"
+        "aiSummary": "AI 요약",
+        "chat": "AI와 대화"
       },
       "chat": "AI와 대화하기",
       "save": "저장하기",
@@ -906,7 +907,9 @@
     "placeholder": "궁금한 점을 입력해주세요",
     "typing": "까치가 답변을 입력 중입니다...",
     "today": "오늘",
-    "errorMessage": "죄송해요, 오류가 발생했어요. 다시 시도해주세요. 🐦"
+    "errorMessage": "죄송해요, 오류가 발생했어요. 다시 시도해주세요. 🐦",
+    "documentWelcomeMessage": "이 가정통신문에 대해 궁금한 점을 물어보세요! 🐦\n문서 내용을 바탕으로 답변해드릴게요.",
+    "nlNotReadyError": "아직 문서 분석이 완료되지 않았어요. 잠시 후 다시 시도해주세요. 🐦"
   },
   "mealTimetable": {
     "sectionTitle": "급식·시간표",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -427,7 +427,8 @@
       "tabs": {
         "full": "Toàn bộ tài liệu",
         "checklist": "Danh sách việc cần làm",
-        "aiSummary": "Tóm tắt AI"
+        "aiSummary": "Tóm tắt AI",
+        "chat": "Hỏi AI"
       },
       "chat": "Trò chuyện với AI",
       "save": "Lưu",
@@ -920,7 +921,9 @@
     "placeholder": "Nhập câu hỏi của bạn tại đây",
     "typing": "Kachi đang nhập câu trả lời...",
     "today": "Hôm nay",
-    "errorMessage": "Xin lỗi, đã xảy ra lỗi. Vui lòng thử lại. 🐦"
+    "errorMessage": "Xin lỗi, đã xảy ra lỗi. Vui lòng thử lại. 🐦",
+    "documentWelcomeMessage": "Hãy hỏi tôi bất cứ điều gì về thông báo này! 🐦\nTôi sẽ trả lời dựa trên nội dung tài liệu.",
+    "nlNotReadyError": "Tài liệu chưa được phân tích xong. Vui lòng thử lại sau giây lát. 🐦"
   },
   "mealTimetable": {
     "sectionTitle": "Bữa ăn & Thời khóa biểu",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -419,7 +419,8 @@
       "tabs": {
         "full": "完整文件",
         "checklist": "待办清单",
-        "aiSummary": "AI摘要"
+        "aiSummary": "AI摘要",
+        "chat": "问AI"
       },
       "chat": "与AI对话",
       "save": "保存",
@@ -903,7 +904,9 @@
     "placeholder": "请输入您想了解的问题",
     "typing": "Kachi正在输入回答...",
     "today": "今天",
-    "errorMessage": "抱歉，出现了错误，请重试。🐦"
+    "errorMessage": "抱歉，出现了错误，请重试。🐦",
+    "documentWelcomeMessage": "请问我关于这份通知书的任何问题！🐦\n我将根据文档内容为您解答。",
+    "nlNotReadyError": "文件分析尚未完成，请稍后再试。🐦"
   },
   "mealTimetable": {
     "sectionTitle": "供餐·课程表",


### PR DESCRIPTION
## 📌 작업 내용

- `src/api/chat.ts` — `SendMessageParams`에 `newsletterId` 파라미터 추가 및 요청 body 포함
- `app/chat/index.tsx` — 라우트 파라미터로 `chatType`·`newsletterId` 수신, DOCUMENT 모드 웰컴 메시지 분기, `CHAT4003`(세션 범위 충돌) · `NL4004`(문서 미완료) 에러 코드 처리
- `app/scan/result.tsx` — AI와 대화하기 버튼 `onPress` 연결 (`chatType: 'DOCUMENT'`, `newsletterId` 전달)
- i18n(ko/en/vi/zh) — `chat.documentWelcomeMessage`, `chat.nlNotReadyError` 번역 키 추가

## 📷 스크린 샷

-

## ⚠️ 참고 사항

- `CHAT4003` 수신 시 `sessionId`를 초기화하고 다음 메시지부터 새 세션으로 재시작
- 세션은 화면 마운트 단위로 유지 — 스캔 결과 화면 재진입 시 항상 새 세션 시작
- DOCUMENT 모드 히스토리는 백엔드 스펙상 10턴 제한

## 🔗 관련 이슈

Closes #107 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 스캔 결과에 AI 요약 및 AI 채팅 탭을 추가했습니다.
  - 스캔 결과에서 문서 기반 AI 채팅으로 바로 이동할 수 있습니다.
  - 채팅 요청에 관련 문서 정보가 함께 전달됩니다.
  - 문서 유형에 맞는 환영 메시지와 안내 문구를 제공합니다.

- **개선 사항**
  - 문서 분석 상태에 따른 안내 메시지를 표시합니다.
  - 채팅 세션 오류 발생 시 자동 재시도 및 상황별 메시지를 제공합니다.
  - 영어, 한국어, 베트남어, 중국어 번역을 지원합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->