### PR TITLE
✨ [Feature] 회원 탈퇴 API 연동

### DIFF
--- a/app/profile/edit.tsx
+++ b/app/profile/edit.tsx
@@ -18,7 +18,14 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Header from '../../src/components/common/Header';
 import ConfirmModal from '../../src/components/common/ConfirmModal';
 import FormField from '../../src/components/auth/FormField';
-import { fetchMyInfo, updateProfile, UserInfo, UserApiError } from '../../src/api/user';
+import {
+  fetchMyInfo,
+  updateProfile,
+  withdrawUser,
+  UserInfo,
+  UserApiError,
+} from '../../src/api/user';
+import { clearSession } from '../../src/api/auth';
 import { phoneNumberSchema } from '../../src/validation/auth';
 import colors from '../../src/constants/colors';
 import layout from '../../src/constants/layout';
@@ -187,6 +194,11 @@ const ProfileEditScreen = () => {
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
   const [withdrawModalVisible, setWithdrawModalVisible] = useState(false);
+  const [withdrawStep, setWithdrawStep] = useState<'confirm' | 'password'>('confirm');
+  const [withdrawPassword, setWithdrawPassword] = useState('');
+  const [showWithdrawPassword, setShowWithdrawPassword] = useState(false);
+  const [withdrawError, setWithdrawError] = useState<string | undefined>();
+  const [withdrawing, setWithdrawing] = useState(false);
   const [editSheetVisible, setEditSheetVisible] = useState(false);
   const [editSheetFocus, setEditSheetFocus] = useState<'name' | 'phone'>('name');
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
@@ -202,6 +214,49 @@ const ProfileEditScreen = () => {
   }, []);
 
   useFocusEffect(loadUserInfo);
+
+  const openWithdrawModal = () => {
+    setWithdrawStep('confirm');
+    setWithdrawPassword('');
+    setShowWithdrawPassword(false);
+    setWithdrawError(undefined);
+    setWithdrawModalVisible(true);
+  };
+
+  const closeWithdrawModal = () => {
+    if (withdrawing) return;
+    setWithdrawModalVisible(false);
+    setWithdrawStep('confirm');
+    setWithdrawPassword('');
+    setShowWithdrawPassword(false);
+    setWithdrawError(undefined);
+  };
+
+  const handleWithdraw = async () => {
+    if (withdrawing || withdrawPassword.length === 0) return;
+
+    setWithdrawing(true);
+    setWithdrawError(undefined);
+    try {
+      await withdrawUser(withdrawPassword);
+      setWithdrawModalVisible(false);
+      setWithdrawPassword('');
+      setShowWithdrawPassword(false);
+      await clearSession();
+    } catch (e) {
+      if (e instanceof UserApiError && e.code === 'AUTH4011') {
+        setWithdrawError(t('profile.editProfile.withdrawWrongPassword'));
+      } else if (e instanceof UserApiError && e.code === 'UNAUTHORIZED') {
+        await clearSession();
+      } else {
+        setWithdrawError(t('profile.editProfile.withdrawFailed'));
+      }
+    } finally {
+      setWithdrawing(false);
+    }
+  };
+
+  const isWithdrawPasswordStep = withdrawStep === 'password';
 
   const openSheet = (focus: 'name' | 'phone') => {
     setEditSheetFocus(focus);
@@ -272,7 +327,7 @@ const ProfileEditScreen = () => {
 
         <TouchableOpacity
           style={styles.withdrawBtn}
-          onPress={() => setWithdrawModalVisible(true)}
+          onPress={openWithdrawModal}
           activeOpacity={0.8}
         >
           <Text style={styles.withdrawText}>{t('profile.editProfile.withdraw')}</Text>
@@ -288,19 +343,51 @@ const ProfileEditScreen = () => {
         onSaved={loadUserInfo}
       />
 
-      <ConfirmModal
-        visible={withdrawModalVisible}
-        onClose={() => setWithdrawModalVisible(false)}
-        icon={<FontAwesome5 name="user-slash" size={26} color={colors.primary[500]} />}
-        title={t('profile.editProfile.withdrawTitle')}
-        description={t('profile.editProfile.withdrawDesc')}
-        warning={t('profile.editProfile.withdrawWarning')}
-        cancelText={t('profile.editProfile.cancel')}
-        onCancel={() => setWithdrawModalVisible(false)}
-        confirmText={t('profile.editProfile.withdraw')}
-        onConfirm={() => {}}
-        confirmDisabled
-      />
+      {isWithdrawPasswordStep ? (
+        <ConfirmModal
+          visible={withdrawModalVisible}
+          onClose={closeWithdrawModal}
+          icon={<Ionicons name="lock-closed" size={26} color={colors.primary[500]} />}
+          title={t('profile.editProfile.withdrawVerifyTitle')}
+          description={t('profile.editProfile.withdrawVerifyDesc')}
+          extraContent={
+            <FormField
+              label={t('profile.editProfile.changePassword.currentPassword')}
+              value={withdrawPassword}
+              onChangeText={(v) => {
+                setWithdrawPassword(v);
+                setWithdrawError(undefined);
+              }}
+              placeholder={t('profile.editProfile.withdrawPasswordPlaceholder')}
+              secureTextEntry={!showWithdrawPassword}
+              rightIcon={showWithdrawPassword ? 'eye-outline' : 'eye-off-outline'}
+              onRightIconPress={() => setShowWithdrawPassword((prev) => !prev)}
+              editable={!withdrawing}
+              autoFocus
+              validationState={withdrawError ? 'error' : undefined}
+              validationMessage={withdrawError}
+            />
+          }
+          cancelText={t('profile.editProfile.cancel')}
+          onCancel={closeWithdrawModal}
+          confirmText={t('profile.editProfile.withdraw')}
+          onConfirm={handleWithdraw}
+          confirmDisabled={withdrawPassword.length === 0 || withdrawing}
+        />
+      ) : (
+        <ConfirmModal
+          visible={withdrawModalVisible}
+          onClose={closeWithdrawModal}
+          icon={<FontAwesome5 name="user-slash" size={26} color={colors.primary[500]} />}
+          title={t('profile.editProfile.withdrawTitle')}
+          description={t('profile.editProfile.withdrawDesc')}
+          warning={t('profile.editProfile.withdrawWarning')}
+          cancelText={t('profile.editProfile.withdrawKeep')}
+          onCancel={closeWithdrawModal}
+          confirmText={t('profile.editProfile.withdrawContinue')}
+          onConfirm={() => setWithdrawStep('password')}
+        />
+      )}
     </View>
   );
 };

--- a/app/profile/edit.tsx
+++ b/app/profile/edit.tsx
@@ -361,7 +361,10 @@ const ProfileEditScreen = () => {
               placeholder={t('profile.editProfile.withdrawPasswordPlaceholder')}
               secureTextEntry={!showWithdrawPassword}
               rightIcon={showWithdrawPassword ? 'eye-outline' : 'eye-off-outline'}
-              onRightIconPress={() => setShowWithdrawPassword((prev) => !prev)}
+              onRightIconPress={() => {
+                if (withdrawing) return;
+                setShowWithdrawPassword((prev) => !prev);
+              }}
               editable={!withdrawing}
               autoFocus
               validationState={withdrawError ? 'error' : undefined}

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -80,9 +80,7 @@ apiClient.interceptors.response.use(
       return apiClient(originalRequest);
     } catch (refreshError) {
       processQueue(refreshError, null);
-      await SecureStore.deleteItemAsync('accessToken');
-      await SecureStore.deleteItemAsync('refreshToken');
-      router.replace('/(auth)/login');
+      await clearSession();
       return Promise.reject(refreshError);
     } finally {
       isRefreshing = false;
@@ -91,8 +89,11 @@ apiClient.interceptors.response.use(
 );
 
 export const clearSession = async (): Promise<void> => {
-  await SecureStore.deleteItemAsync('accessToken');
-  await SecureStore.deleteItemAsync('refreshToken');
+  // 각 삭제를 독립 실행해 하나가 실패해도 나머지 삭제와 화면 이동을 보장
+  await Promise.allSettled([
+    SecureStore.deleteItemAsync('accessToken'),
+    SecureStore.deleteItemAsync('refreshToken'),
+  ]);
   router.replace('/(auth)/login');
 };
 

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -90,6 +90,12 @@ apiClient.interceptors.response.use(
   }
 );
 
+export const clearSession = async (): Promise<void> => {
+  await SecureStore.deleteItemAsync('accessToken');
+  await SecureStore.deleteItemAsync('refreshToken');
+  router.replace('/(auth)/login');
+};
+
 export const logout = async (): Promise<void> => {
   try {
     const accessToken = await SecureStore.getItemAsync('accessToken');
@@ -104,9 +110,7 @@ export const logout = async (): Promise<void> => {
   } catch {
     // API 실패해도 로컬 토큰 삭제 후 로그인으로 이동
   } finally {
-    await SecureStore.deleteItemAsync('accessToken');
-    await SecureStore.deleteItemAsync('refreshToken');
-    router.replace('/(auth)/login');
+    await clearSession();
   }
 };
 

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -123,6 +123,26 @@ export const updateNotificationPreference = async (
   }
 };
 
+export const withdrawUser = async (currentPassword: string): Promise<void> => {
+  let responseData: { success?: boolean; code?: string; message?: string } | undefined;
+  try {
+    const headers = await getAuthHeader();
+    const { data } = await apiClient.delete('/api/v1/users/me', {
+      headers,
+      data: { currentPassword },
+    });
+    responseData = data;
+  } catch (error) {
+    throw wrapError(error);
+  }
+  if (responseData?.success === false) {
+    throw new UserApiError(
+      responseData.code ?? 'UNKNOWN',
+      responseData.message ?? '알 수 없는 오류'
+    );
+  }
+};
+
 export interface ChangePasswordPayload {
   currentPassword: string;
   newPassword: string;

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -76,7 +76,7 @@ const ConfirmModal = ({
     <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
       <KeyboardAvoidingView
         style={styles.flex}
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       >
         <TouchableWithoutFeedback onPress={onClose}>
           <View style={styles.overlay}>

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -5,6 +5,8 @@ import {
   Modal,
   TouchableOpacity,
   TouchableWithoutFeedback,
+  KeyboardAvoidingView,
+  Platform,
   StyleSheet,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
@@ -19,6 +21,7 @@ interface Props {
   title: string;
   description: string;
   warning?: string;
+  extraContent?: ReactNode;
   cancelText: string;
   onCancel: () => void;
   confirmText: string;
@@ -34,6 +37,7 @@ const ConfirmModal = ({
   title,
   description,
   warning,
+  extraContent,
   cancelText,
   onCancel,
   confirmText,
@@ -51,6 +55,7 @@ const ConfirmModal = ({
           <Text style={styles.warningText}>{warning}</Text>
         </View>
       ) : null}
+      {extraContent ? <View style={styles.extraContent}>{extraContent}</View> : null}
       <View style={styles.btnRow}>
         <TouchableOpacity style={styles.cancelBtn} onPress={onCancel} activeOpacity={0.8}>
           <Text style={styles.cancelBtnText}>{cancelText}</Text>
@@ -69,11 +74,16 @@ const ConfirmModal = ({
 
   return (
     <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
-      <TouchableWithoutFeedback onPress={onClose}>
-        <View style={styles.overlay}>
-          <TouchableWithoutFeedback onPress={() => {}}>{cardContent}</TouchableWithoutFeedback>
-        </View>
-      </TouchableWithoutFeedback>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <TouchableWithoutFeedback onPress={onClose}>
+          <View style={styles.overlay}>
+            <TouchableWithoutFeedback onPress={() => {}}>{cardContent}</TouchableWithoutFeedback>
+          </View>
+        </TouchableWithoutFeedback>
+      </KeyboardAvoidingView>
     </Modal>
   );
 };
@@ -81,6 +91,9 @@ const ConfirmModal = ({
 export default ConfirmModal;
 
 const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
   overlay: {
     flex: 1,
     backgroundColor: 'rgba(0, 0, 0, 0.45)',
@@ -120,6 +133,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     gap: 11,
     alignItems: 'center',
+    width: '100%',
+  },
+  extraContent: {
     width: '100%',
   },
   warningText: {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -612,6 +612,13 @@
       "withdrawTitle": "Are you sure you want to leave?",
       "withdrawDesc": "Your account and all data will be\npermanently deleted.",
       "withdrawWarning": "All saved documents, child info, and calendar events will be deleted and cannot be recovered.",
+      "withdrawPasswordPlaceholder": "Enter your current password",
+      "withdrawFailed": "Failed to delete your account. Please try again.",
+      "withdrawWrongPassword": "Current password is incorrect.",
+      "withdrawKeep": "Keep my account",
+      "withdrawContinue": "Continue to delete",
+      "withdrawVerifyTitle": "Verify it's you",
+      "withdrawVerifyDesc": "For your account's security,\nenter your current password.",
       "cancel": "Cancel"
     },
     "editEmail": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -612,6 +612,13 @@
       "withdrawTitle": "정말 탈퇴하시겠어요?",
       "withdrawDesc": "탈퇴하면 계정과 모든 데이터가\n영구적으로 삭제돼요.",
       "withdrawWarning": "저장된 문서, 자녀 정보, 캘린더 일정이 모두 삭제되며 복구할 수 없어요.",
+      "withdrawPasswordPlaceholder": "현재 비밀번호를 입력해주세요",
+      "withdrawFailed": "탈퇴에 실패했어요. 다시 시도해주세요.",
+      "withdrawWrongPassword": "현재 비밀번호가 올바르지 않아요.",
+      "withdrawKeep": "조금 더 써볼게요",
+      "withdrawContinue": "탈퇴 계속하기",
+      "withdrawVerifyTitle": "본인 확인이 필요해요",
+      "withdrawVerifyDesc": "계정 보호를 위해\n현재 비밀번호를 입력해주세요.",
       "cancel": "취소"
     },
     "editEmail": {

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -620,6 +620,13 @@
       "withdrawTitle": "Bạn có chắc muốn hủy tài khoản không?",
       "withdrawDesc": "Khi hủy tài khoản, tài khoản và toàn bộ dữ liệu\nsẽ bị xóa vĩnh viễn.",
       "withdrawWarning": "Tất cả tài liệu đã lưu, thông tin về con và lịch sẽ bị xóa và không thể khôi phục.",
+      "withdrawPasswordPlaceholder": "Nhập mật khẩu hiện tại",
+      "withdrawFailed": "Hủy tài khoản thất bại. Vui lòng thử lại.",
+      "withdrawWrongPassword": "Mật khẩu hiện tại không chính xác.",
+      "withdrawKeep": "Giữ tài khoản của tôi",
+      "withdrawContinue": "Tiếp tục hủy",
+      "withdrawVerifyTitle": "Cần xác minh danh tính",
+      "withdrawVerifyDesc": "Để bảo vệ tài khoản,\nvui lòng nhập mật khẩu hiện tại.",
       "cancel": "Hủy"
     },
     "editEmail": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -612,6 +612,13 @@
       "withdrawTitle": "确定要注销账号吗？",
       "withdrawDesc": "注销后，账号和所有数据\n将被永久删除。",
       "withdrawWarning": "已保存的文件、孩子信息和日历日程都会被删除，且无法恢复。",
+      "withdrawPasswordPlaceholder": "请输入当前密码",
+      "withdrawFailed": "注销失败，请重试。",
+      "withdrawWrongPassword": "当前密码不正确。",
+      "withdrawKeep": "保留我的账号",
+      "withdrawContinue": "继续注销",
+      "withdrawVerifyTitle": "需要验证身份",
+      "withdrawVerifyDesc": "为保护账号安全，\n请输入当前密码。",
       "cancel": "取消"
     },
     "editEmail": {


### PR DESCRIPTION
## 📌 작업 내용

- `DELETE /api/v1/users/me` 연동 (`withdrawUser`) — 기존 `changePassword`와 동일하게 `success === false` 응답도 `UserApiError`로 처리
- 탈퇴 시 세션 정리를 위해 `logout()`의 토큰 삭제·로그인 이동 로직을 `clearSession()`으로 추출해 재사용 (탈퇴 후 로그아웃 API 재호출 방지)
- 되돌릴 수 없는 동작이라 확인 모달을 2단계로 구성
  - 1단계: 삭제 데이터 안내 + `조금 더 써볼게요` / `탈퇴 계속하기`
  - 2단계: 현재 비밀번호 입력 후에만 실제 탈퇴 실행
- `ConfirmModal`에 선택 prop `extraContent`(경고 배너와 버튼 사이 슬롯)와 `KeyboardAvoidingView` 추가
- 에러 처리: `AUTH4011` → 비밀번호 오류 인라인 표시, `UNAUTHORIZED` → 로그인 화면 이동, 그 외 → 실패 안내
- 요청 중에는 입력·버튼·모달 닫기 비활성화로 중복 요청 방지
- 다국어(ko/en/vi/zh) 문구 추가

## ⚠️ 참고 사항

- `ConfirmModal`은 로그아웃 모달([app/(tabs)/profile.tsx](app/(tabs)/profile.tsx))에서도 사용 중입니다. `extraContent`는 선택 prop이라 기존 사용처 UI 변경은 없으나 회귀 확인 부탁드립니다.
- 비밀번호 오류 문구는 `changePassword.errorCurrentPassword`(합쇼체)를 재사용하지 않고 앱 전반의 해요체에 맞춘 `withdrawWrongPassword`를 새로 추가했습니다.
- `src/validation/auth.ts`의 zod 타입 에러 5건은 이 PR 이전부터 있던 것으로 범위에 포함하지 않았습니다.

## 🔗 관련 이슈

Closes #109


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 회원 탈퇴 전 확인 절차가 추가되었습니다.
  - 탈퇴 진행 시 현재 비밀번호를 입력해 본인 확인을 거치며, 비밀번호 오류와 탈퇴 실패 상황을 안내합니다.
  - 탈퇴가 완료되면 세션이 정리되고 로그인 화면으로 이동합니다.
  - 확인 모달에서 추가 안내와 비밀번호 입력을 지원합니다.

- **다국어 지원**
  - 회원 탈퇴 및 본인 확인 관련 문구가 한국어, 영어, 베트남어, 중국어로 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->